### PR TITLE
Multicollat support

### DIFF
--- a/packages/graph-client/.graphclientrc.yml
+++ b/packages/graph-client/.graphclientrc.yml
@@ -51,9 +51,9 @@ additionalTypeDefs: |
   extend type Query {
     getActiveRewardConfigs: [RewardConfig!]!
     getRewardConfig(id: ID!): RewardConfig
-    getAddressRewardsForEpoch(address: String!, rewardConfigId: ID!, epoch: Int!): RewardResults!
-    getAllRewardsForEpoch(rewardConfigId: ID!, epoch: Int!): [RewardResults!]!
-    getAllRewardsForLastEpoch(rewardConfigId: ID!): [RewardResults!]!
+    getAddressRewardsForEpoch(address: String!, rewardConfigId: ID!, epoch: Int!, rewardToUsd: Float): RewardResults!
+    getAllRewardsForEpoch(rewardConfigId: ID!, epoch: Int!, rewardToUsd: Float): [RewardResults!]!
+    getAllRewardsForLastEpoch(rewardConfigId: ID!, rewardToUsd: Float): [RewardResults!]!
   }
 
 additionalResolvers:

--- a/packages/graph-client/.graphclientrc.yml
+++ b/packages/graph-client/.graphclientrc.yml
@@ -2,7 +2,7 @@ sources:
   - name: gtrade-stats
     handler:
       graphql:
-        endpoint: https://api.thegraph.com/subgraphs/name/gainsnetwork-org/{context.graphName:gtrade-stats-arbitrum}
+        endpoint: https://api.thegraph.com/subgraphs/name/gainsnetwork-org/{context.graphName:gtrade-stats-mumbai}
         retry: 3
     transforms:
       - autoPagination:

--- a/packages/graph-client/.graphclientrc.yml
+++ b/packages/graph-client/.graphclientrc.yml
@@ -19,7 +19,7 @@ additionalTypeDefs: |
   # Types
   type RewardDistributionP {
     loyalty: Float!
-    volume: Float!
+    fee: Float!
     absSkill: Float!
     relSkill: Float!
     diversity: Float!
@@ -39,7 +39,7 @@ additionalTypeDefs: |
     address: String!
     total: Float!
     loyalty: Float!
-    volume: Float!
+    fee: Float!
     absSkill: Float!
     relSkill: Float!
     diversity: Float!

--- a/packages/graph-client/.graphclientrc.yml
+++ b/packages/graph-client/.graphclientrc.yml
@@ -33,6 +33,8 @@ additionalTypeDefs: |
     numEpochs: Int!
     startingEpoch: Int!
     rewardDistribution: RewardDistributionP!
+    rewardsPairIx: Int
+    capFeeRewards: Boolean
   }
 
   type RewardResults {
@@ -50,8 +52,8 @@ additionalTypeDefs: |
     getActiveRewardConfigs: [RewardConfig!]!
     getRewardConfig(id: ID!): RewardConfig
     getAddressRewardsForEpoch(address: String!, rewardConfigId: ID!, epoch: Int!): RewardResults!
-    getAllRewardsForEpoch(rewardConfigId: ID!, epoch: Int!, skip: Int = 0, first: Int = 1000): [RewardResults!]!
-    getAllRewardsForLastEpoch(rewardConfigId: ID!, skip: Int = 0, first: Int = 1000): [RewardResults!]!
+    getAllRewardsForEpoch(rewardConfigId: ID!, epoch: Int!): [RewardResults!]!
+    getAllRewardsForLastEpoch(rewardConfigId: ID!): [RewardResults!]!
   }
 
 additionalResolvers:

--- a/packages/graph-client/helpers/rewards.ts
+++ b/packages/graph-client/helpers/rewards.ts
@@ -183,3 +183,10 @@ export const getPointsFromDiversityTreshold = (existingFees: number) => {
   }
   return 0;
 };
+
+export const COLLATERALS = {
+  _ALL_: "_all_",
+  DAI: "dai",
+  ETH: "eth",
+  ARB: "arb",
+};

--- a/packages/graph-client/helpers/rewards.ts
+++ b/packages/graph-client/helpers/rewards.ts
@@ -3,6 +3,7 @@ import {
   EpochType,
   RewardConfig,
   RewardResults,
+  Collateral,
 } from "../.graphclient";
 import { EpochTradingPoints, LoyaltyTier } from "../types/rewards";
 
@@ -185,8 +186,8 @@ export const getPointsFromDiversityTreshold = (existingFees: number) => {
 };
 
 export const COLLATERALS = {
-  _ALL_: "_all_",
-  DAI: "dai",
-  ETH: "eth",
-  ARB: "arb",
+  _ALL_: "_all_" as Collateral,
+  DAI: "dai" as Collateral,
+  ETH: "eth" as Collateral,
+  ARB: "arb" as Collateral,
 };

--- a/packages/graph-client/helpers/rewards.ts
+++ b/packages/graph-client/helpers/rewards.ts
@@ -73,7 +73,7 @@ export const convertPointsToRewardsForUser = (
     address: userPoints.address,
     total: 0,
     loyalty: 0,
-    volume: 0,
+    fee: 0,
     absSkill: 0,
     relSkill: 0,
     diversity: 0,
@@ -86,10 +86,10 @@ export const convertPointsToRewardsForUser = (
     rewards.rewardDistribution.loyalty * epochTotalRewards
   );
 
-  rewardResults.volume = convertPointShareToRewards(
-    userPoints.volumePoints,
-    protocolPoints.volumePoints,
-    rewards.rewardDistribution.volume * epochTotalRewards
+  rewardResults.fee = convertPointShareToRewards(
+    userPoints.feePoints,
+    protocolPoints.feePoints,
+    rewards.rewardDistribution.fee * epochTotalRewards
   );
 
   rewardResults.absSkill = convertPointShareToRewards(
@@ -112,7 +112,7 @@ export const convertPointsToRewardsForUser = (
 
   rewardResults.total =
     rewardResults.loyalty +
-    rewardResults.volume +
+    rewardResults.fee +
     rewardResults.absSkill +
     rewardResults.relSkill +
     rewardResults.diversity;
@@ -128,7 +128,7 @@ export const transformEpochTradingPointsRecord = (
   epochNumber: Number(record.epochNumber),
   address: record.address,
   loyaltyPoints: Number(record.loyaltyPoints),
-  volumePoints: Number(record.volumePoints),
+  feePoints: Number(record.feePoints),
   absSkillPoints: Number(record.absSkillPoints),
   relSkillPoints: Number(record.relSkillPoints),
   diversityPoints: Number(record.diversityPoints),

--- a/packages/graph-client/helpers/rewards.ts
+++ b/packages/graph-client/helpers/rewards.ts
@@ -157,3 +157,29 @@ export const getPointsFromNextTier = (points: number): number => {
   }
   return 0;
 };
+
+export const DIVERSITY_THRESHOLD = 0;
+export const getDiversityGroupFromPairIndex = (
+  pairIndex: number,
+  groupIndex: number
+): number => {
+  let groupId = 0;
+  if (groupIndex == 0 && (pairIndex == 0 || pairIndex == 1)) {
+    groupId = 0;
+  } else if (groupIndex == 0 && pairIndex > 1) {
+    groupId = 1;
+  } else if (groupIndex == 1 || groupIndex == 8 || groupIndex == 9) {
+    groupId = 2;
+  } else if (groupIndex == 6 || groupIndex == 7) {
+    groupId = 3;
+  } else {
+    groupId = 4;
+  }
+  return groupId;
+};
+export const getPointsFromDiversityTreshold = (existingFees: number) => {
+  if (existingFees < DIVERSITY_THRESHOLD) {
+    return DIVERSITY_THRESHOLD - existingFees;
+  }
+  return 0;
+};

--- a/packages/graph-client/helpers/rewards.ts
+++ b/packages/graph-client/helpers/rewards.ts
@@ -141,19 +141,19 @@ export const loyaltyTiers: LoyaltyTier[] = [
   { lowerBound: 400, upperBound: Infinity, returnValue: 50 },
 ];
 
-export const getLoyaltyTier = (points: number): number => {
+export const getLoyaltyTier = (fees: number): number => {
   for (const tier of loyaltyTiers) {
-    if (points >= tier.lowerBound && points < tier.upperBound) {
+    if (fees >= tier.lowerBound && fees < tier.upperBound) {
       return tier.returnValue;
     }
   }
   return 0;
 };
 
-export const getPointsFromNextTier = (points: number): number => {
+export const getFeesFromNextTier = (fees: number): number => {
   for (const tier of loyaltyTiers) {
-    if (points >= tier.lowerBound && points < tier.upperBound) {
-      return tier.upperBound - points;
+    if (fees >= tier.lowerBound && fees < tier.upperBound) {
+      return tier.upperBound - fees;
     }
   }
   return 0;
@@ -178,7 +178,7 @@ export const getDiversityGroupFromPairIndex = (
   }
   return groupId;
 };
-export const getPointsFromDiversityTreshold = (existingFees: number) => {
+export const getFeesFromDiversityTreshold = (existingFees: number) => {
   if (existingFees < DIVERSITY_THRESHOLD) {
     return DIVERSITY_THRESHOLD - existingFees;
   }

--- a/packages/graph-client/package.json
+++ b/packages/graph-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gainsnetwork/graph-client",
-  "version": "0.0.1-rc16",
+  "version": "0.0.1-rc17",
   "description": "Client library for Gains Network GraphQL API",
   "main": ".graphclient/index.js",
   "types": ".graphclient/index.d.ts",

--- a/packages/graph-client/package.json
+++ b/packages/graph-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gainsnetwork/graph-client",
-  "version": "0.0.1-rc17",
+  "version": "0.0.1-rc18",
   "description": "Client library for Gains Network GraphQL API",
   "main": ".graphclient/index.js",
   "types": ".graphclient/index.d.ts",

--- a/packages/graph-client/package.json
+++ b/packages/graph-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gainsnetwork/graph-client",
-  "version": "0.0.1-rc19",
+  "version": "0.0.1-rc20",
   "description": "Client library for Gains Network GraphQL API",
   "main": ".graphclient/index.js",
   "types": ".graphclient/index.d.ts",

--- a/packages/graph-client/package.json
+++ b/packages/graph-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gainsnetwork/graph-client",
-  "version": "0.0.1-rc20",
+  "version": "0.0.1-rc21",
   "description": "Client library for Gains Network GraphQL API",
   "main": ".graphclient/index.js",
   "types": ".graphclient/index.d.ts",

--- a/packages/graph-client/package.json
+++ b/packages/graph-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gainsnetwork/graph-client",
-  "version": "0.0.1-rc22",
+  "version": "0.0.1-rc23",
   "description": "Client library for Gains Network GraphQL API",
   "main": ".graphclient/index.js",
   "types": ".graphclient/index.d.ts",

--- a/packages/graph-client/package.json
+++ b/packages/graph-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gainsnetwork/graph-client",
-  "version": "0.0.1-rc18",
+  "version": "0.0.1-rc19",
   "description": "Client library for Gains Network GraphQL API",
   "main": ".graphclient/index.js",
   "types": ".graphclient/index.d.ts",

--- a/packages/graph-client/package.json
+++ b/packages/graph-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gainsnetwork/graph-client",
-  "version": "0.0.1-rc15",
+  "version": "0.0.1-rc16",
   "description": "Client library for Gains Network GraphQL API",
   "main": ".graphclient/index.js",
   "types": ".graphclient/index.d.ts",

--- a/packages/graph-client/package.json
+++ b/packages/graph-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gainsnetwork/graph-client",
-  "version": "0.0.1-rc21",
+  "version": "0.0.1-rc22",
   "description": "Client library for Gains Network GraphQL API",
   "main": ".graphclient/index.js",
   "types": ".graphclient/index.d.ts",

--- a/packages/graph-client/queries/gtrade-stats.gql
+++ b/packages/graph-client/queries/gtrade-stats.gql
@@ -10,22 +10,26 @@ fragment BaseEpochTradingPointsRecord on EpochTradingPointsRecord {
   diversityPoints
 }
 
+fragment BaseEpochTradingStatsRecord on EpochTradingStatsRecord {
+  id
+  address
+  epochType
+  epochNumber
+  totalVolumePerGroup
+  totalBorrowingFees
+  pairsTraded
+  totalPnl
+  totalPnlPercentage
+  totalGovFees
+  totalReferralFees
+  totalTriggerFees
+  totalStakerFees
+  totalLpFees
+}
+
 query GetEpochTradingStatsRecord($id: ID!) {
   epochTradingStatsRecord(id: $id) {
-    id
-    address
-    epochType
-    epochNumber
-    totalVolumePerGroup
-    totalBorrowingFees
-    pairsTraded
-    totalPnl
-    totalPnlPercentage
-    totalGovFees
-    totalReferralFees
-    totalTriggerFees
-    totalStakerFees
-    totalLpFees
+    ...BaseEpochTradingStatsRecord
   }
 }
 
@@ -41,20 +45,7 @@ query GetEpochTradingStatsRecordsForEpoch(
   $where: EpochTradingStatsRecord_filter
 ) {
   epochTradingStatsRecords(skip: $skip, first: $first, where: $where) {
-    id
-    address
-    epochType
-    epochNumber
-    totalVolumePerGroup
-    totalBorrowingFees
-    pairsTraded
-    totalPnl
-    totalPnlPercentage
-    totalGovFees
-    totalReferralFees
-    totalTriggerFees
-    totalStakerFees
-    totalLpFees
+    ...BaseEpochTradingStatsRecord
   }
 }
 
@@ -82,6 +73,21 @@ query GetTraderAndProtocolPointsRecordsForEpoch(
     ...BaseEpochTradingPointsRecord
   }
   protocol: epochTradingPointsRecord(id: $protocolId) {
+    ...BaseEpochTradingPointsRecord
+  }
+}
+
+query GetTraderAndProtocolRecordsForEpoch($traderId: ID!, $protocolId: ID!) {
+  traderStats: epochTradingStatsRecord(id: $traderId) {
+    ...BaseEpochTradingStatsRecord
+  }
+  protocolStats: epochTradingStatsRecord(id: $protocolId) {
+    ...BaseEpochTradingStatsRecord
+  }
+  traderPoints: epochTradingPointsRecord(id: $traderId) {
+    ...BaseEpochTradingPointsRecord
+  }
+  protocolPoints: epochTradingPointsRecord(id: $protocolId) {
     ...BaseEpochTradingPointsRecord
   }
 }

--- a/packages/graph-client/queries/gtrade-stats.gql
+++ b/packages/graph-client/queries/gtrade-stats.gql
@@ -8,6 +8,7 @@ fragment BaseEpochTradingPointsRecord on EpochTradingPointsRecord {
   absSkillPoints
   relSkillPoints
   diversityPoints
+  totalFeesPaid
 }
 
 fragment BaseEpochTradingStatsRecord on EpochTradingStatsRecord {

--- a/packages/graph-client/queries/gtrade-stats.gql
+++ b/packages/graph-client/queries/gtrade-stats.gql
@@ -4,7 +4,7 @@ fragment BaseEpochTradingPointsRecord on EpochTradingPointsRecord {
   epochType
   epochNumber
   loyaltyPoints
-  volumePoints
+  feePoints
   absSkillPoints
   relSkillPoints
   diversityPoints

--- a/packages/graph-client/queries/rewards.gql
+++ b/packages/graph-client/queries/rewards.gql
@@ -12,6 +12,8 @@ fragment BaseRewardConfig on RewardConfig {
     relSkill
     diversity
   }
+  rewardsPairIx
+  capFeeRewards
 }
 
 fragment BaseRewardResults on RewardResults {
@@ -56,16 +58,8 @@ query GetAllRewardsForEpoch($rewardConfigId: ID!, $epoch: Int!) {
   }
 }
 
-query GetAllRewardsForLastEpoch(
-  $rewardConfigId: ID!
-  $skip: Int = 0
-  $first: Int = 1000
-) {
-  getAllRewardsForLastEpoch(
-    rewardConfigId: $rewardConfigId
-    skip: $skip
-    first: $first
-  ) {
+query GetAllRewardsForLastEpoch($rewardConfigId: ID!) {
+  getAllRewardsForLastEpoch(rewardConfigId: $rewardConfigId) {
     ...BaseRewardResults
   }
 }

--- a/packages/graph-client/queries/rewards.gql
+++ b/packages/graph-client/queries/rewards.gql
@@ -7,7 +7,7 @@ fragment BaseRewardConfig on RewardConfig {
   startingEpoch
   rewardDistribution {
     loyalty
-    volume
+    fee
     absSkill
     relSkill
     diversity
@@ -18,7 +18,7 @@ fragment BaseRewardResults on RewardResults {
   address
   total
   loyalty
-  volume
+  fee
   absSkill
   relSkill
   diversity

--- a/packages/graph-client/queries/rewards.gql
+++ b/packages/graph-client/queries/rewards.gql
@@ -42,24 +42,37 @@ query GetAddressRewardsForEpoch(
   $address: String!
   $rewardConfigId: ID!
   $epoch: Int!
+  $rewardToUsd: Float
 ) {
   getAddressRewardsForEpoch(
     address: $address
     rewardConfigId: $rewardConfigId
     epoch: $epoch
+    rewardToUsd: $rewardToUsd
   ) {
     ...BaseRewardResults
   }
 }
 
-query GetAllRewardsForEpoch($rewardConfigId: ID!, $epoch: Int!) {
-  getAllRewardsForEpoch(rewardConfigId: $rewardConfigId, epoch: $epoch) {
+query GetAllRewardsForEpoch(
+  $rewardConfigId: ID!
+  $epoch: Int!
+  $rewardToUsd: Float
+) {
+  getAllRewardsForEpoch(
+    rewardConfigId: $rewardConfigId
+    epoch: $epoch
+    rewardToUsd: $rewardToUsd
+  ) {
     ...BaseRewardResults
   }
 }
 
-query GetAllRewardsForLastEpoch($rewardConfigId: ID!) {
-  getAllRewardsForLastEpoch(rewardConfigId: $rewardConfigId) {
+query GetAllRewardsForLastEpoch($rewardConfigId: ID!, $rewardToUsd: Float) {
+  getAllRewardsForLastEpoch(
+    rewardConfigId: $rewardConfigId
+    rewardToUsd: $rewardToUsd
+  ) {
     ...BaseRewardResults
   }
 }

--- a/packages/graph-client/resolvers/rewards/getActiveRewardConfigs.ts
+++ b/packages/graph-client/resolvers/rewards/getActiveRewardConfigs.ts
@@ -7,16 +7,16 @@ import {
 export const ARBITRUM_STIP_REWARDS = {
   id: "arbitrum-stip-0",
   active: true,
-  totalRewards: 4000000,
+  totalRewards: 3825000,
   epochType: "week" as EpochType,
-  numEpochs: 14,
+  numEpochs: 15,
   startingEpoch: 0,
   rewardDistribution: {
     loyalty: 0.1,
     fee: 0.7,
-    absSkill: 0.1,
+    absSkill: 0.15,
     relSkill: 0.05,
-    diversity: 0.05,
+    diversity: 0.0,
   },
 };
 

--- a/packages/graph-client/resolvers/rewards/getActiveRewardConfigs.ts
+++ b/packages/graph-client/resolvers/rewards/getActiveRewardConfigs.ts
@@ -13,7 +13,7 @@ export const ARBITRUM_STIP_REWARDS = {
   startingEpoch: 0,
   rewardDistribution: {
     loyalty: 0.1,
-    volume: 0.7,
+    fee: 0.7,
     absSkill: 0.1,
     relSkill: 0.05,
     diversity: 0.05,

--- a/packages/graph-client/resolvers/rewards/getActiveRewardConfigs.ts
+++ b/packages/graph-client/resolvers/rewards/getActiveRewardConfigs.ts
@@ -18,6 +18,8 @@ export const ARBITRUM_STIP_REWARDS = {
     relSkill: 0.05,
     diversity: 0.0,
   },
+  rewardsPairIx: 109,
+  capFeeRewards: true,
 };
 
 export const getActiveRewardConfigs: QueryResolvers["getActiveRewardConfigs"] =

--- a/packages/graph-client/resolvers/rewards/getAddressRewardsForEpoch.ts
+++ b/packages/graph-client/resolvers/rewards/getAddressRewardsForEpoch.ts
@@ -17,6 +17,7 @@ export const getAddressRewardsForEpoch: QueryResolvers["getAddressRewardsForEpoc
     context
   ): Promise<Query["getAddressRewardsForEpoch"]> => {
     const { address, epoch, rewardConfigId } = args;
+    let { rewardToUsd } = args;
     const { chainId } = context;
     const sdk = getBuiltGraphSDK();
     const rewardConfig = (
@@ -58,18 +59,19 @@ export const getAddressRewardsForEpoch: QueryResolvers["getAddressRewardsForEpoc
 
     // Cap fee rewards if necessary
     if (rewardConfig.capFeeRewards) {
-      const rewardsPairIx: number = rewardConfig.rewardsPairIx;
-      const prices = (await (
-        await fetch("https://backend-pricing.eu.gains.trade/charts")
-      ).json()) as { opens: number[] };
-      const rewardsToUsd: number = prices.opens[rewardsPairIx];
-      const rewardsInUsd =
-        rewardConfig.rewardDistribution.fee *
-        (rewardConfig.totalRewards / rewardConfig.numEpochs) *
-        rewardsToUsd;
-      const protocolFees = addressAndProtocolPoints.protocol.totalFeesPaid;
-      if (rewardsInUsd > protocolFees) {
-        rewardConfig.rewardDistribution.fee *= protocolFees / rewardsInUsd;
+      if (rewardToUsd) {
+        const rewardsInUsd =
+          rewardConfig.rewardDistribution.fee *
+          (rewardConfig.totalRewards / rewardConfig.numEpochs) *
+          rewardToUsd;
+        const protocolFees = addressAndProtocolPoints.protocol.totalFeesPaid;
+        if (rewardsInUsd > protocolFees) {
+          rewardConfig.rewardDistribution.fee *= protocolFees / rewardsInUsd;
+        }
+      } else {
+        console.warn(
+          "No rewardToUsd provided, so not capping fee rewards. This may result in incorrect rewards."
+        );
       }
     }
 

--- a/packages/graph-client/resolvers/rewards/getAddressRewardsForEpoch.ts
+++ b/packages/graph-client/resolvers/rewards/getAddressRewardsForEpoch.ts
@@ -16,8 +16,7 @@ export const getAddressRewardsForEpoch: QueryResolvers["getAddressRewardsForEpoc
     args: QuerygetAddressRewardsForEpochArgs,
     context
   ): Promise<Query["getAddressRewardsForEpoch"]> => {
-    const { address, epoch, rewardConfigId } = args;
-    let { rewardToUsd } = args;
+    const { address, epoch, rewardConfigId, rewardToUsd } = args;
     const { chainId } = context;
     const sdk = getBuiltGraphSDK();
     const rewardConfig = (

--- a/packages/graph-client/resolvers/rewards/getAllRewardsForEpoch.ts
+++ b/packages/graph-client/resolvers/rewards/getAllRewardsForEpoch.ts
@@ -8,6 +8,7 @@ import {
   getBuiltGraphSDK,
 } from "./../../.graphclient/index.js";
 import {
+  COLLATERALS,
   convertPointsToRewardsForUser,
   transformEpochTradingPointsRecord,
 } from "../../helpers/rewards.js";
@@ -88,6 +89,7 @@ const fetchEpochTradingPointsRecords = async (
   const whereClause = {
     epochType: rewardConfig.epochType,
     epochNumber: epoch,
+    collateral: COLLATERALS._ALL_, // @todo this is hardcoded for now - need to support further configs later
   };
 
   if (lastId) {

--- a/packages/graph-client/resolvers/rewards/getAllRewardsForEpoch.ts
+++ b/packages/graph-client/resolvers/rewards/getAllRewardsForEpoch.ts
@@ -20,8 +20,7 @@ export const getAllRewardsForEpoch: QueryResolvers["getAllRewardsForEpoch"] =
     args: QuerygetAllRewardsForEpochArgs,
     context
   ): Promise<Query["getAllRewardsForEpoch"]> => {
-    const { rewardConfigId, epoch } = args;
-    let { rewardToUsd } = args;
+    const { rewardConfigId, epoch, rewardToUsd } = args;
     const { chainId } = context;
     const sdk = getBuiltGraphSDK();
     const rewardConfig = (

--- a/packages/graph-client/resolvers/rewards/getAllRewardsForLastEpoch.ts
+++ b/packages/graph-client/resolvers/rewards/getAllRewardsForLastEpoch.ts
@@ -13,7 +13,7 @@ export const getAllRewardsForLastEpoch: QueryResolvers["getAllRewardsForLastEpoc
     args: QuerygetAllRewardsForLastEpochArgs,
     context
   ): Promise<Query["getAllRewardsForLastEpoch"]> => {
-    const { rewardConfigId } = args;
+    const { rewardConfigId, rewardToUsd } = args;
     const { chainId } = context;
     const sdk = getBuiltGraphSDK();
     const rewardConfig = (
@@ -36,6 +36,7 @@ export const getAllRewardsForLastEpoch: QueryResolvers["getAllRewardsForLastEpoc
         {
           rewardConfigId,
           epoch: currentEpoch - 1,
+          rewardToUsd,
         },
         { ...context, graphName: STATS_SUBGRAPH[+chainId] }
       )

--- a/packages/graph-client/types/rewards.ts
+++ b/packages/graph-client/types/rewards.ts
@@ -9,6 +9,7 @@ export type EpochTradingPoints = {
   absSkillPoints: number;
   relSkillPoints: number;
   diversityPoints: number;
+  totalFeesPaid: number;
 };
 
 export type LoyaltyTier = {

--- a/packages/graph-client/types/rewards.ts
+++ b/packages/graph-client/types/rewards.ts
@@ -5,7 +5,7 @@ export type EpochTradingPoints = {
   epochNumber: number;
   address: string;
   loyaltyPoints: number;
-  volumePoints: number;
+  feePoints: number;
   absSkillPoints: number;
   relSkillPoints: number;
   diversityPoints: number;

--- a/packages/stats-subgraph/abis/GNSPriceAggregator.json
+++ b/packages/stats-subgraph/abis/GNSPriceAggregator.json
@@ -1,0 +1,994 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_linkToken",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IUniswapV3Pool",
+        "name": "_tokenDaiLp",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_twapInterval",
+        "type": "uint32"
+      },
+      {
+        "internalType": "contract IGNSTradingStorage",
+        "name": "_storageT",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IGNSPairsStorage",
+        "name": "_pairsStorage",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IChainlinkFeed",
+        "name": "_linkPriceFeed",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IChainlinkFeed",
+        "name": "_collateralPriceFeed",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_minAnswers",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_nodes",
+        "type": "address[]"
+      },
+      {
+        "internalType": "bytes32[2]",
+        "name": "_jobIds",
+        "type": "bytes32[2]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "T",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "orderId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "price",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "spreadP",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "open",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "high",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "low",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct IGNSTradingCallbacks.AggregatorAnswer",
+        "name": "a",
+        "type": "tuple"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum IGNSPriceAggregator.OrderType",
+        "name": "orderType",
+        "type": "uint8"
+      }
+    ],
+    "name": "CallbackExecuted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "ChainlinkCancelled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "ChainlinkFulfilled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "ChainlinkRequested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "value",
+        "type": "address"
+      }
+    ],
+    "name": "CollateralPriceFeedUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "jobId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "JobIdUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "value",
+        "type": "address"
+      }
+    ],
+    "name": "LinkPriceFeedUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "MinAnswersUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "value",
+        "type": "address"
+      }
+    ],
+    "name": "NodeAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldNode",
+        "type": "address"
+      }
+    ],
+    "name": "NodeRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldNode",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newNode",
+        "type": "address"
+      }
+    ],
+    "name": "NodeReplaced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "value",
+        "type": "address"
+      }
+    ],
+    "name": "PairsStorageUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "request",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "orderId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "node",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint16",
+        "name": "pairIndex",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "referencePrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint112",
+        "name": "linkFee",
+        "type": "uint112"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isLookback",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "usedInMedian",
+        "type": "bool"
+      }
+    ],
+    "name": "PriceReceived",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "orderId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "job",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "pairIndex",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum IGNSPriceAggregator.OrderType",
+        "name": "orderType",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "nodesCount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "linkFeePerNode",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fromBlock",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isLookback",
+        "type": "bool"
+      }
+    ],
+    "name": "PriceRequested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "newValue",
+        "type": "uint32"
+      }
+    ],
+    "name": "TwapIntervalUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract IUniswapV3Pool",
+        "name": "newValue",
+        "type": "address"
+      }
+    ],
+    "name": "UniV3PoolUpdated",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "a",
+        "type": "address"
+      }
+    ],
+    "name": "addNode",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "claimBackLink",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "collateralPriceFeed",
+    "outputs": [
+      {
+        "internalType": "contract IChainlinkFeed",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "requestId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "priceData",
+        "type": "uint256"
+      }
+    ],
+    "name": "fulfill",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCollateralDecimalDifference",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCollateralPrecision",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "pairIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "enum IGNSPriceAggregator.OrderType",
+        "name": "orderType",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "leveragedPosDai",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "fromBlock",
+        "type": "uint256"
+      }
+    ],
+    "name": "getPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isGnsToken0InLp",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "jobIds",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "pairIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "leveragedPosDai",
+        "type": "uint256"
+      }
+    ],
+    "name": "linkFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "linkPriceFeed",
+    "outputs": [
+      {
+        "internalType": "contract IChainlinkFeed",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "lookbackOrderAnswers",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "open",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "high",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "low",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "ts",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minAnswers",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "nodes",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "pairIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "openFeeP",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "orderIdByRequest",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "orders",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "pairIndex",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint112",
+        "name": "linkFeePerNode",
+        "type": "uint112"
+      },
+      {
+        "internalType": "enum IGNSPriceAggregator.OrderType",
+        "name": "orderType",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bool",
+        "name": "active",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "isLookback",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "ordersAnswers",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pairsStorage",
+    "outputs": [
+      {
+        "internalType": "contract IGNSPairsStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "removeNode",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "a",
+        "type": "address"
+      }
+    ],
+    "name": "replaceNode",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "jobId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "setLimitJobId",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "jobId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "setMarketJobId",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "storageT",
+    "outputs": [
+      {
+        "internalType": "contract IGNSTradingStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "tokenPriceDai",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "twapInterval",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "uniV3Pool",
+    "outputs": [
+      {
+        "internalType": "contract IUniswapV3Pool",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IChainlinkFeed",
+        "name": "value",
+        "type": "address"
+      }
+    ],
+    "name": "updateCollateralPriceFeed",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IChainlinkFeed",
+        "name": "value",
+        "type": "address"
+      }
+    ],
+    "name": "updateLinkPriceFeed",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateMinAnswers",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IGNSPairsStorage",
+        "name": "value",
+        "type": "address"
+      }
+    ],
+    "name": "updatePairsStorage",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "_twapInterval",
+        "type": "uint32"
+      }
+    ],
+    "name": "updateTwapInterval",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IUniswapV3Pool",
+        "name": "_uniV3Pool",
+        "type": "address"
+      }
+    ],
+    "name": "updateUniV3Pool",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/packages/stats-subgraph/abis/IChainlinkFeed.json
+++ b/packages/stats-subgraph/abis/IChainlinkFeed.json
@@ -1,0 +1,35 @@
+[
+  {
+    "inputs": [],
+    "name": "latestRoundData",
+    "outputs": [
+      {
+        "internalType": "uint80",
+        "name": "",
+        "type": "uint80"
+      },
+      {
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint80",
+        "name": "",
+        "type": "uint80"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/packages/stats-subgraph/config/arbitrum.json
+++ b/packages/stats-subgraph/config/arbitrum.json
@@ -1,11 +1,13 @@
 {
   "network": "arbitrum-one",
-  "gnsTradingCallbacksV6_4_1": {
-    "address": "0x298a695906e16aeA0a184A2815A76eAd1a0b7522",
-    "startBlock": 136035360
-  },
-  "gnsPairsStorageV6": {
-    "address": "0xf67Df2a4339eC1591615d94599081Dd037960d4b",
-    "startBlock": 136035360
+  "DAI": {
+    "gnsTradingCallbacksV6_4_1": {
+      "address": "0x298a695906e16aeA0a184A2815A76eAd1a0b7522",
+      "startBlock": 136035360
+    },
+    "gnsPairsStorageV6": {
+      "address": "0xf67Df2a4339eC1591615d94599081Dd037960d4b",
+      "startBlock": 136035360
+    }
   }
 }

--- a/packages/stats-subgraph/config/mumbai.json
+++ b/packages/stats-subgraph/config/mumbai.json
@@ -1,11 +1,13 @@
 {
   "network": "mumbai",
-  "gnsTradingCallbacksV6_4_1": {
-    "address": "0xA7443A20B42f9156F7D9DB01e51523C42CAC8eCE",
-    "startBlock": 40700000
-  },
-  "gnsPairsStorageV6": {
-    "address": "0x2b497ff78bA1F803141Ecca0F98eF3c5B5B64d26",
-    "startBlock": 40700000
+  "DAI": {
+    "gnsTradingCallbacksV6_4_1": {
+      "address": "0xA7443A20B42f9156F7D9DB01e51523C42CAC8eCE",
+      "startBlock": 40700000
+    },
+    "gnsPairsStorageV6": {
+      "address": "0x2b497ff78bA1F803141Ecca0F98eF3c5B5B64d26",
+      "startBlock": 40700000
+    }
   }
 }

--- a/packages/stats-subgraph/config/polygon.json
+++ b/packages/stats-subgraph/config/polygon.json
@@ -1,11 +1,13 @@
 {
   "network": "matic",
-  "gnsTradingCallbacksV6_4_1": {
-    "address": "0x82e59334da8C667797009BBe82473B55c7A6b311",
-    "startBlock": 48152959
-  },
-  "gnsPairsStorageV6": {
-    "address": "0x6e5326e944F528c243B9Ca5d14fe5C9269a8c922",
-    "startBlock": 48152959
+  "DAI": {
+    "gnsTradingCallbacksV6_4_1": {
+      "address": "0x82e59334da8C667797009BBe82473B55c7A6b311",
+      "startBlock": 48152959
+    },
+    "gnsPairsStorageV6": {
+      "address": "0x6e5326e944F528c243B9Ca5d14fe5C9269a8c922",
+      "startBlock": 48152959
+    }
   }
 }

--- a/packages/stats-subgraph/schema.gql
+++ b/packages/stats-subgraph/schema.gql
@@ -3,6 +3,13 @@ enum EpochType {
   week
 }
 
+enum Collateral {
+  _all_
+  dai
+  eth
+  arb
+}
+
 type EpochTradingStatsRecord @entity {
   "Address-type-number-collateral"
   id: ID!
@@ -15,6 +22,9 @@ type EpochTradingStatsRecord @entity {
 
   "Epoch Number"
   epochNumber: Int!
+
+  "Collateral"
+  collateral: Collateral!
 
   "Total Volume"
   totalVolumePerGroup: [BigDecimal!]!

--- a/packages/stats-subgraph/schema.gql
+++ b/packages/stats-subgraph/schema.gql
@@ -63,6 +63,7 @@ type EpochTradingPointsRecord @entity {
   address: String!
   epochNumber: Int!
   epochType: EpochType!
+  collateral: Collateral!
   totalFeesPaid: BigDecimal!
   pnl: BigDecimal!
   pnlPercentage: BigDecimal!

--- a/packages/stats-subgraph/schema.gql
+++ b/packages/stats-subgraph/schema.gql
@@ -69,7 +69,7 @@ type EpochTradingPointsRecord @entity {
   pnlPercentage: BigDecimal!
   groupsTraded: [BigDecimal!]!
   loyaltyPoints: BigDecimal!
-  volumePoints: BigDecimal!
+  feePoints: BigDecimal!
   absSkillPoints: BigDecimal!
   relSkillPoints: BigDecimal!
   diversityPoints: BigDecimal!

--- a/packages/stats-subgraph/schema.gql
+++ b/packages/stats-subgraph/schema.gql
@@ -4,7 +4,7 @@ enum EpochType {
 }
 
 type EpochTradingStatsRecord @entity {
-  "Address-type-number"
+  "Address-type-number-collateral"
   id: ID!
 
   "Address"

--- a/packages/stats-subgraph/src/handlers/GNSTradingCallbacksV6_4_1/index.ts
+++ b/packages/stats-subgraph/src/handlers/GNSTradingCallbacksV6_4_1/index.ts
@@ -27,6 +27,8 @@ import {
 } from "../../utils/contract";
 
 export function handleMarketExecuted(event: MarketExecuted): void {
+  // Get collateral stack
+  const collateral = getCollateral(event.address.toHexString());
   const trade = event.params.t;
   const open = event.params.open;
   const daiSentToTrader = convertDai(event.params.daiSentToTrader);

--- a/packages/stats-subgraph/src/handlers/GNSTradingCallbacksV6_4_1/index.ts
+++ b/packages/stats-subgraph/src/handlers/GNSTradingCallbacksV6_4_1/index.ts
@@ -147,6 +147,7 @@ export function handleGovFeeCharged(event: GovFeeCharged): void {
   const trader = event.params.trader.toHexString();
   const govFee = convertDaiToDecimal(event.params.valueDai);
   const timestamp = event.block.timestamp.toI32();
+
   log.info("[handleGovFeeCharged] {}", [event.transaction.hash.toHexString()]);
   addGovFeeStats(trader, govFee, timestamp, collateralDetails.collateral);
   updateFeeBasedPoints(trader, govFee, timestamp, collateralDetails.collateral);

--- a/packages/stats-subgraph/src/handlers/GNSTradingCallbacksV6_4_1/index.ts
+++ b/packages/stats-subgraph/src/handlers/GNSTradingCallbacksV6_4_1/index.ts
@@ -49,7 +49,7 @@ function getCollateralDetails(event: ethereum.Event): CollateralDetails {
 }
 
 export function handleMarketExecuted(event: MarketExecuted): void {
-  const networkDetails = getCollateralDetails(event);
+  const collateralDetails = getCollateralDetails(event);
   const trade = event.params.t;
   const open = event.params.open;
   const collateralSentToTrader = convertDaiToDecimal(
@@ -63,9 +63,9 @@ export function handleMarketExecuted(event: MarketExecuted): void {
 
   if (open) {
     _handleOpenTrade(
-      networkDetails.network,
-      networkDetails.collateral,
-      networkDetails.collateralToUsd,
+      collateralDetails.network,
+      collateralDetails.collateral,
+      collateralDetails.collateralToUsd,
       trade.trader.toHexString(),
       trade.pairIndex,
       volume,
@@ -73,9 +73,9 @@ export function handleMarketExecuted(event: MarketExecuted): void {
     );
   } else {
     _handleCloseTrade(
-      networkDetails.network,
-      networkDetails.collateral,
-      networkDetails.collateralToUsd,
+      collateralDetails.network,
+      collateralDetails.collateral,
+      collateralDetails.collateralToUsd,
       trade.trader.toHexString(),
       trade.pairIndex,
       leverage,
@@ -87,7 +87,7 @@ export function handleMarketExecuted(event: MarketExecuted): void {
 }
 
 export function handleLimitExecuted(event: LimitExecuted): void {
-  const networkDetails = getCollateralDetails(event);
+  const collateralDetails = getCollateralDetails(event);
   const trade = event.params.t;
   const orderType = event.params.orderType;
   const collateralSentToTrader = convertDaiToDecimal(
@@ -99,9 +99,9 @@ export function handleLimitExecuted(event: LimitExecuted): void {
   log.info("[handleLimitExecuted] {}", [event.transaction.hash.toHexString()]);
   if (orderType == 3) {
     _handleOpenTrade(
-      networkDetails.network,
-      networkDetails.collateral,
-      networkDetails.collateralToUsd,
+      collateralDetails.network,
+      collateralDetails.collateral,
+      collateralDetails.collateralToUsd,
       trade.trader.toHexString(),
       trade.pairIndex,
       volume,
@@ -109,9 +109,9 @@ export function handleLimitExecuted(event: LimitExecuted): void {
     );
   } else {
     _handleCloseTrade(
-      networkDetails.network,
-      networkDetails.collateral,
-      networkDetails.collateralToUsd,
+      collateralDetails.network,
+      collateralDetails.collateral,
+      collateralDetails.collateralToUsd,
       trade.trader.toHexString(),
       trade.pairIndex,
       leverage,
@@ -123,7 +123,7 @@ export function handleLimitExecuted(event: LimitExecuted): void {
 }
 
 export function handleBorrowingFeeCharged(event: BorrowingFeeCharged): void {
-  const networkDetails = getCollateralDetails(event);
+  const collateralDetails = getCollateralDetails(event);
   const trader = event.params.trader.toHexString();
   const borrowingFee = convertDaiToDecimal(event.params.feeValueDai);
   const timestamp = event.block.timestamp.toI32();
@@ -134,31 +134,31 @@ export function handleBorrowingFeeCharged(event: BorrowingFeeCharged): void {
     trader,
     borrowingFee,
     timestamp,
-    networkDetails.collateral
+    collateralDetails.collateral
   );
 
   // Calculate and add normalized stats
-  const borrowingFeeUsd = borrowingFee.times(networkDetails.collateralToUsd);
+  const borrowingFeeUsd = borrowingFee.times(collateralDetails.collateralToUsd);
   addBorrowingFeeStats(trader, borrowingFeeUsd, timestamp, null);
 }
 
 export function handleGovFeeCharged(event: GovFeeCharged): void {
-  const networkDetails = getCollateralDetails(event);
+  const collateralDetails = getCollateralDetails(event);
   const trader = event.params.trader.toHexString();
   const govFee = convertDaiToDecimal(event.params.valueDai);
   const timestamp = event.block.timestamp.toI32();
   log.info("[handleGovFeeCharged] {}", [event.transaction.hash.toHexString()]);
-  addGovFeeStats(trader, govFee, timestamp, networkDetails.collateral);
-  updateFeeBasedPoints(trader, govFee, timestamp, networkDetails.collateral);
+  addGovFeeStats(trader, govFee, timestamp, collateralDetails.collateral);
+  updateFeeBasedPoints(trader, govFee, timestamp, collateralDetails.collateral);
 
   // Calculate and add normalized stats
-  const govFeeUsd = govFee.times(networkDetails.collateralToUsd);
+  const govFeeUsd = govFee.times(collateralDetails.collateralToUsd);
   addGovFeeStats(trader, govFeeUsd, timestamp, null);
   updateFeeBasedPoints(trader, govFeeUsd, timestamp, null);
 }
 
 export function handleReferralFeeCharged(event: ReferralFeeCharged): void {
-  const networkDetails = getCollateralDetails(event);
+  const collateralDetails = getCollateralDetails(event);
   const trader = event.params.trader.toHexString();
   const referralFee = convertDaiToDecimal(event.params.valueDai);
   const timestamp = event.block.timestamp.toI32();
@@ -169,70 +169,81 @@ export function handleReferralFeeCharged(event: ReferralFeeCharged): void {
     trader,
     referralFee,
     timestamp,
-    networkDetails.collateral
+    collateralDetails.collateral
   );
   updateFeeBasedPoints(
     trader,
     referralFee,
     timestamp,
-    networkDetails.collateral
+    collateralDetails.collateral
   );
 
   // Calculate and add normalized stats
-  const referralFeeUsd = referralFee.times(networkDetails.collateralToUsd);
+  const referralFeeUsd = referralFee.times(collateralDetails.collateralToUsd);
   addReferralFeeStats(trader, referralFeeUsd, timestamp, null);
   updateFeeBasedPoints(trader, referralFeeUsd, timestamp, null);
 }
 
 export function handleTriggerFeeCharged(event: TriggerFeeCharged): void {
-  const networkDetails = getCollateralDetails(event);
+  const collateralDetails = getCollateralDetails(event);
   const trader = event.params.trader.toHexString();
   const triggerFee = convertDaiToDecimal(event.params.valueDai);
   const timestamp = event.block.timestamp.toI32();
   log.info("[handleTriggerFeeCharged] {}", [
     event.transaction.hash.toHexString(),
   ]);
-  addTriggerFeeStats(trader, triggerFee, timestamp, networkDetails.collateral);
+  addTriggerFeeStats(
+    trader,
+    triggerFee,
+    timestamp,
+    collateralDetails.collateral
+  );
   updateFeeBasedPoints(
     trader,
     triggerFee,
     timestamp,
-    networkDetails.collateral
+    collateralDetails.collateral
   );
 
   // Calculate and add normalized stats
-  const triggerFeeUsd = triggerFee.times(networkDetails.collateralToUsd);
+  const triggerFeeUsd = triggerFee.times(collateralDetails.collateralToUsd);
   addTriggerFeeStats(trader, triggerFeeUsd, timestamp, null);
   updateFeeBasedPoints(trader, triggerFeeUsd, timestamp, null);
 }
 
 export function handleStakerFeeCharged(event: SssFeeCharged): void {
-  const networkDetails = getCollateralDetails(event);
+  const collateralDetails = getCollateralDetails(event);
   const trader = event.params.trader.toHexString();
   const stakerFee = convertDaiToDecimal(event.params.valueDai);
   const timestamp = event.block.timestamp.toI32();
   log.info("[handleStakerFeeCharged] {}", [
     event.transaction.hash.toHexString(),
   ]);
-  addStakerFeeStats(trader, stakerFee, timestamp, networkDetails.collateral);
-  updateFeeBasedPoints(trader, stakerFee, timestamp, networkDetails.collateral);
+  addStakerFeeStats(trader, stakerFee, timestamp, collateralDetails.collateral);
+  updateFeeBasedPoints(
+    trader,
+    stakerFee,
+    timestamp,
+    collateralDetails.collateral
+  );
 
   // Calculate and add normalized stats
-  const stakerFeeUsd = stakerFee.times(networkDetails.collateralToUsd);
+  const stakerFeeUsd = stakerFee.times(collateralDetails.collateralToUsd);
   addStakerFeeStats(trader, stakerFeeUsd, timestamp, null);
+  updateFeeBasedPoints(trader, stakerFeeUsd, timestamp, null);
 }
 
 export function handleLpFeeCharged(event: DaiVaultFeeCharged): void {
-  const networkDetails = getCollateralDetails(event);
+  const collateralDetails = getCollateralDetails(event);
   const trader = event.params.trader.toHexString();
   const lpFee = convertDaiToDecimal(event.params.valueDai);
   const timestamp = event.block.timestamp.toI32();
   log.info("[handleLpFeeCharged] {}", [event.transaction.hash.toHexString()]);
-  addLpFeeStats(trader, lpFee, timestamp, networkDetails.collateral);
-  updateFeeBasedPoints(trader, lpFee, timestamp, networkDetails.collateral);
+  addLpFeeStats(trader, lpFee, timestamp, collateralDetails.collateral);
+  updateFeeBasedPoints(trader, lpFee, timestamp, collateralDetails.collateral);
 
   // Calculate and add normalized stats
-  const lpFeeUsd = lpFee.times(networkDetails.collateralToUsd);
+  const lpFeeUsd = lpFee.times(collateralDetails.collateralToUsd);
   addLpFeeStats(trader, lpFeeUsd, timestamp, null);
   updateFeeBasedPoints(trader, lpFeeUsd, timestamp, null);
 }

--- a/packages/stats-subgraph/src/handlers/GNSTradingCallbacksV6_4_1/index.ts
+++ b/packages/stats-subgraph/src/handlers/GNSTradingCallbacksV6_4_1/index.ts
@@ -118,64 +118,98 @@ export function handleLimitExecuted(event: LimitExecuted): void {
 }
 
 export function handleBorrowingFeeCharged(event: BorrowingFeeCharged): void {
+  const { collateral, collateralToUsd } = getCollateralDetails(event);
   const trader = event.params.trader.toHexString();
   const borrowingFee = convertDaiToDecimal(event.params.feeValueDai);
   const timestamp = event.block.timestamp.toI32();
   log.info("[handleBorrowingFeeCharged] {}", [
     event.transaction.hash.toHexString(),
   ]);
-  addBorrowingFeeStats(trader, borrowingFee, timestamp);
+  addBorrowingFeeStats(trader, borrowingFee, timestamp, collateral);
+
+  // Calculate and add normalized stats
+  const borrowingFeeUsd = borrowingFee.times(collateralToUsd);
+  addBorrowingFeeStats(trader, borrowingFeeUsd, timestamp, null);
 }
 
 export function handleGovFeeCharged(event: GovFeeCharged): void {
+  const { collateral, collateralToUsd } = getCollateralDetails(event);
   const trader = event.params.trader.toHexString();
   const govFee = convertDaiToDecimal(event.params.valueDai);
   const timestamp = event.block.timestamp.toI32();
   log.info("[handleGovFeeCharged] {}", [event.transaction.hash.toHexString()]);
-  addGovFeeStats(trader, govFee, timestamp);
-  updateFeeBasedPoints(trader, govFee, timestamp);
+  addGovFeeStats(trader, govFee, timestamp, collateral);
+  updateFeeBasedPoints(trader, govFee, timestamp, collateral);
+  
+  // Calculate and add normalized stats
+  const govFeeUsd = govFee.times(collateralToUsd);
+  addGovFeeStats(trader, govFeeUsd, timestamp, null);
+  updateFeeBasedPoints(trader, govFeeUsd, timestamp, null
 }
 
 export function handleReferralFeeCharged(event: ReferralFeeCharged): void {
+  const { collateral, collateralToUsd } = getCollateralDetails(event);
   const trader = event.params.trader.toHexString();
   const referralFee = convertDaiToDecimal(event.params.valueDai);
   const timestamp = event.block.timestamp.toI32();
   log.info("[handleReferralFeeCharged] {}", [
     event.transaction.hash.toHexString(),
   ]);
-  addReferralFeeStats(trader, referralFee, timestamp);
-  updateFeeBasedPoints(trader, referralFee, timestamp);
+  addReferralFeeStats(trader, referralFee, timestamp, collateral);
+  updateFeeBasedPoints(trader, referralFee, timestamp, collateral);
+
+  // Calculate and add normalized stats
+  const referralFeeUsd = referralFee.times(collateralToUsd);
+  addReferralFeeStats(trader, referralFeeUsd, timestamp, null);
+  updateFeeBasedPoints(trader, referralFeeUsd, timestamp, null);
 }
 
 export function handleTriggerFeeCharged(event: TriggerFeeCharged): void {
+  const { collateral, collateralToUsd } = getCollateralDetails(event);
   const trader = event.params.trader.toHexString();
   const triggerFee = convertDaiToDecimal(event.params.valueDai);
   const timestamp = event.block.timestamp.toI32();
   log.info("[handleTriggerFeeCharged] {}", [
     event.transaction.hash.toHexString(),
   ]);
-  addTriggerFeeStats(trader, triggerFee, timestamp);
-  updateFeeBasedPoints(trader, triggerFee, timestamp);
+  addTriggerFeeStats(trader, triggerFee, timestamp, collateral);
+  updateFeeBasedPoints(trader, triggerFee, timestamp, collateral);
+
+  // Calculate and add normalized stats
+  const triggerFeeUsd = triggerFee.times(collateralToUsd);
+  addTriggerFeeStats(trader, triggerFeeUsd, timestamp, null);
+  updateFeeBasedPoints(trader, triggerFeeUsd, timestamp, null
 }
 
 export function handleStakerFeeCharged(event: SssFeeCharged): void {
+  const { collateral, collateralToUsd } = getCollateralDetails(event);
   const trader = event.params.trader.toHexString();
   const stakerFee = convertDaiToDecimal(event.params.valueDai);
   const timestamp = event.block.timestamp.toI32();
   log.info("[handleStakerFeeCharged] {}", [
     event.transaction.hash.toHexString(),
   ]);
-  addStakerFeeStats(trader, stakerFee, timestamp);
-  updateFeeBasedPoints(trader, stakerFee, timestamp);
+  addStakerFeeStats(trader, stakerFee, timestamp, collateral);
+  updateFeeBasedPoints(trader, stakerFee, timestamp, collateral);
+
+  // Calculate and add normalized stats
+  const stakerFeeUsd = stakerFee.times(collateralToUsd);
+  addStakerFeeStats(trader, stakerFeeUsd, timestamp, null);
 }
 
 export function handleLpFeeCharged(event: DaiVaultFeeCharged): void {
+  const { collateral, collateralToUsd } = getCollateralDetails(event);
   const trader = event.params.trader.toHexString();
   const lpFee = convertDaiToDecimal(event.params.valueDai);
   const timestamp = event.block.timestamp.toI32();
   log.info("[handleLpFeeCharged] {}", [event.transaction.hash.toHexString()]);
-  addLpFeeStats(trader, lpFee, timestamp);
-  updateFeeBasedPoints(trader, lpFee, timestamp);
+  addLpFeeStats(trader, lpFee, timestamp, collateral);
+  updateFeeBasedPoints(trader, lpFee, timestamp, collateral);
+
+  // Calculate and add normalized stats
+  const lpFeeUsd = lpFee.times(collateralToUsd);
+  addLpFeeStats(trader, lpFeeUsd, timestamp, null);
+  updateFeeBasedPoints(trader, lpFeeUsd, timestamp, null);
 }
 
 function _handleOpenTrade(

--- a/packages/stats-subgraph/src/handlers/GNSTradingCallbacksV6_4_1/index.ts
+++ b/packages/stats-subgraph/src/handlers/GNSTradingCallbacksV6_4_1/index.ts
@@ -187,11 +187,25 @@ function _handleOpenTrade(
   positionSize: BigDecimal,
   timestamp: i32
 ): void {
+  const groupIndex = getGroupIndex(network, collateral, pairIndex).toI32();
+  // Add collateral specific stats
   addOpenTradeStats({
+    collateral,
     address: trader,
     pairIndex: pairIndex.toI32(),
-    groupIndex: getGroupIndex(network, collateral, pairIndex).toI32(),
+    groupIndex,
     positionSize,
+    timestamp,
+  });
+
+  // Calculate and add normalized stats
+  const positionSizeUsd = positionSize.times(collateralToUsd);
+  addOpenTradeStats({
+    collateral: null,
+    address: trader,
+    pairIndex: pairIndex.toI32(),
+    groupIndex,
+    positionSize: positionSizeUsd,
     timestamp,
   });
 }
@@ -207,18 +221,35 @@ function _handleCloseTrade(
   timestamp: i32,
   collateralSentToTrader: BigDecimal
 ): void {
+  const groupIndex = getGroupIndex(network, collateral, pairIndex).toI32();
   const initialCollateral = positionSize.div(leverage);
   const pnl = collateralSentToTrader.minus(initialCollateral);
   const pnlPercentage = pnl
     .div(initialCollateral)
     .times(BigDecimal.fromString("100"));
 
+  // Add collateral specific stats
   addCloseTradeStats({
+    collateral,
     address: trader,
     pairIndex: pairIndex.toI32(),
-    groupIndex: getGroupIndex(network, collateral, pairIndex).toI32(),
+    groupIndex,
     positionSize,
     pnl,
+    pnlPercentage,
+    timestamp,
+  });
+
+  // Calculate and add normalized stats
+  const positionSizeUsd = positionSize.times(collateralToUsd);
+  const pnlUsd = pnl.times(collateralToUsd);
+  addCloseTradeStats({
+    collateral: null,
+    address: trader,
+    pairIndex: pairIndex.toI32(),
+    groupIndex,
+    positionSize: positionSizeUsd,
+    pnl: pnlUsd,
     pnlPercentage,
     timestamp,
   });

--- a/packages/stats-subgraph/src/utils/access/calculatePoints.ts
+++ b/packages/stats-subgraph/src/utils/access/calculatePoints.ts
@@ -174,7 +174,7 @@ export function updateRelativeSkillPoints(
   protocolWeeklyPoints.save();
 }
 
-// @todo - add volume thresholds
+// @todo - add volume thresholds for diversity groups
 // @todo - is groupNumber accurate here...? btc/eth = 0, crypto = 1, forex = 2, commodities = 3?
 export function updateDiversityPoints(
   userDailyPoints: EpochTradingPointsRecord,
@@ -199,6 +199,7 @@ export function updateDiversityPoints(
     groupId = 4;
   }
 
+  // @todo Are we comparing against cumulative volume or just per trade? Needs to be cumulative for the epoch duration.
   if (groupId < 4) {
     volumeThreshold = VOLUME_THRESHOLDS[groupId];
     if (
@@ -296,7 +297,7 @@ export function updateFeeBasedPoints(
     false
   );
 
-  updateVolumePoints(
+  updateFeePoints(
     stat,
     userDailyStats,
     userWeeklyStats,
@@ -312,7 +313,7 @@ export function updateFeeBasedPoints(
   );
 }
 
-export function updateVolumePoints(
+export function updateFeePoints(
   stat: BigDecimal,
   userDailyStats: EpochTradingPointsRecord,
   userWeeklyStats: EpochTradingPointsRecord,
@@ -327,12 +328,11 @@ export function updateVolumePoints(
   protocolWeeklyStats.totalFeesPaid =
     protocolWeeklyStats.totalFeesPaid.plus(stat);
 
-  // Updating volume points
-  userDailyStats.volumePoints = userDailyStats.volumePoints.plus(stat);
-  userWeeklyStats.volumePoints = userWeeklyStats.volumePoints.plus(stat);
-  protocolDailyStats.volumePoints = protocolDailyStats.volumePoints.plus(stat);
-  protocolWeeklyStats.volumePoints =
-    protocolWeeklyStats.volumePoints.plus(stat);
+  // Updating fee points
+  userDailyStats.feePoints = userDailyStats.feePoints.plus(stat);
+  userWeeklyStats.feePoints = userWeeklyStats.feePoints.plus(stat);
+  protocolDailyStats.feePoints = protocolDailyStats.feePoints.plus(stat);
+  protocolWeeklyStats.feePoints = protocolWeeklyStats.feePoints.plus(stat);
 
   // Saving all the entities
   userDailyStats.save();
@@ -371,7 +371,6 @@ export function updateLoyaltyPoints(
   protocolWeeklyStats.save();
 }
 
-// @todo - should we just make this identical to gCredits? Same with volume.
 export function calculateLoyaltyPoints(fees: BigDecimal): BigDecimal {
   if (
     fees >= BigDecimal.fromString("8") &&
@@ -450,7 +449,7 @@ export function createOrLoadEpochTradingPointsRecord(
     epochTradingPointsRecord.diversityPoints = BigDecimal.fromString("0");
     epochTradingPointsRecord.absSkillPoints = BigDecimal.fromString("0");
     epochTradingPointsRecord.relSkillPoints = BigDecimal.fromString("0");
-    epochTradingPointsRecord.volumePoints = BigDecimal.fromString("0");
+    epochTradingPointsRecord.feePoints = BigDecimal.fromString("0");
     if (save) {
       epochTradingPointsRecord.save();
     }

--- a/packages/stats-subgraph/src/utils/access/calculatePoints.ts
+++ b/packages/stats-subgraph/src/utils/access/calculatePoints.ts
@@ -7,6 +7,7 @@ import {
   PROTOCOL,
   VOLUME_THRESHOLDS,
   ONE_BD,
+  COLLATERALS,
 } from "../constants";
 
 export function updatePointsOnClose(
@@ -418,8 +419,13 @@ export function createOrLoadEpochTradingPointsRecord(
   save: boolean
 ): EpochTradingPointsRecord {
   log.info(
-    "[createOrLoadEpochTradingPointsRecord] address {}, epochType {}, epochNumber {}",
-    [address, epochType.toString(), epochNumber.toString()]
+    "[createOrLoadEpochTradingPointsRecord] address {}, epochType {}, epochNumber {}, collateral {}",
+    [
+      address,
+      epochType.toString(),
+      epochNumber.toString(),
+      collateral ? collateral : "_all_",
+    ]
   );
   const id = generateId(address, epochType, epochNumber, collateral);
   let epochTradingPointsRecord = EpochTradingPointsRecord.load(id);
@@ -428,6 +434,9 @@ export function createOrLoadEpochTradingPointsRecord(
     epochTradingPointsRecord.address = address;
     epochTradingPointsRecord.epochNumber = epochNumber;
     epochTradingPointsRecord.epochType = epochType;
+    epochTradingPointsRecord.collateral = collateral
+      ? collateral
+      : COLLATERALS._ALL_;
     epochTradingPointsRecord.totalFeesPaid = BigDecimal.fromString("0");
     epochTradingPointsRecord.pnl = BigDecimal.fromString("0");
     epochTradingPointsRecord.pnlPercentage = BigDecimal.fromString("0");

--- a/packages/stats-subgraph/src/utils/access/calculatePoints.ts
+++ b/packages/stats-subgraph/src/utils/access/calculatePoints.ts
@@ -13,6 +13,7 @@ export function updatePointsOnClose(
   address: string,
   weekNumber: i32,
   dayNumber: i32,
+  collateral: string | null,
   pnl: BigDecimal,
   pnlPercentage: BigDecimal,
   groupNumber: i32,
@@ -24,24 +25,28 @@ export function updatePointsOnClose(
     address,
     EPOCH_TYPE.DAY,
     dayNumber,
+    collateral,
     false
   );
   const protocolDailyPoints = createOrLoadEpochTradingPointsRecord(
     PROTOCOL,
     EPOCH_TYPE.DAY,
     dayNumber,
+    collateral,
     false
   );
   const userWeeklyPoints = createOrLoadEpochTradingPointsRecord(
     address,
     EPOCH_TYPE.WEEK,
     weekNumber,
+    collateral,
     false
   );
   const protocolWeeklyPoints = createOrLoadEpochTradingPointsRecord(
     PROTOCOL,
     EPOCH_TYPE.WEEK,
     weekNumber,
+    collateral,
     false
   );
 
@@ -252,7 +257,8 @@ export function calculateSkillPoints(
 export function updateFeeBasedPoints(
   address: string,
   stat: BigDecimal,
-  timestamp: i32
+  timestamp: i32,
+  collateral: string | null
 ): void {
   const currentDayNumber = determineEpochNumber(timestamp, EPOCH_TYPE.DAY);
   const currentWeekNumber = determineEpochNumber(timestamp, EPOCH_TYPE.WEEK);
@@ -261,6 +267,7 @@ export function updateFeeBasedPoints(
     address,
     EPOCH_TYPE.DAY,
     currentDayNumber,
+    collateral,
     false
   );
 
@@ -268,6 +275,7 @@ export function updateFeeBasedPoints(
     address,
     EPOCH_TYPE.WEEK,
     currentWeekNumber,
+    collateral,
     false
   );
 
@@ -275,6 +283,7 @@ export function updateFeeBasedPoints(
     PROTOCOL,
     EPOCH_TYPE.DAY,
     currentDayNumber,
+    collateral,
     false
   );
 
@@ -282,6 +291,7 @@ export function updateFeeBasedPoints(
     PROTOCOL,
     EPOCH_TYPE.WEEK,
     currentWeekNumber,
+    collateral,
     false
   );
 
@@ -387,22 +397,31 @@ export function calculateLoyaltyPoints(fees: BigDecimal): BigDecimal {
 export function generateId(
   address: string,
   epochType: string,
-  epochNumber: i32
+  epochNumber: i32,
+  collateral: string | null
 ): string {
-  return address + "-" + epochType + "-" + epochNumber.toString();
+  return (
+    address +
+    "-" +
+    epochType +
+    "-" +
+    epochNumber.toString() +
+    (collateral ? "-" + collateral : "")
+  );
 }
 
 export function createOrLoadEpochTradingPointsRecord(
   address: string,
   epochType: string,
   epochNumber: i32,
+  collateral: string | null,
   save: boolean
 ): EpochTradingPointsRecord {
   log.info(
     "[createOrLoadEpochTradingPointsRecord] address {}, epochType {}, epochNumber {}",
     [address, epochType.toString(), epochNumber.toString()]
   );
-  const id = generateId(address, epochType, epochNumber);
+  const id = generateId(address, epochType, epochNumber, collateral);
   let epochTradingPointsRecord = EpochTradingPointsRecord.load(id);
   if (epochTradingPointsRecord == null) {
     epochTradingPointsRecord = new EpochTradingPointsRecord(id);

--- a/packages/stats-subgraph/src/utils/access/epochTradingStatsRecord.ts
+++ b/packages/stats-subgraph/src/utils/access/epochTradingStatsRecord.ts
@@ -33,8 +33,13 @@ export function createOrLoadEpochTradingStatsRecord(
   save: boolean
 ): EpochTradingStatsRecord {
   log.info(
-    "[createOrLoadEpochTradingStatsRecord] address {}, epochType {}, epochNumber {}",
-    [address, epochType.toString(), epochNumber.toString()]
+    "[createOrLoadEpochTradingStatsRecord] address {}, epochType {}, epochNumber {}, collateral {}",
+    [
+      address,
+      epochType.toString(),
+      epochNumber.toString(),
+      collateral ? collateral : "_all_",
+    ]
   );
   const id = generateAggregateTradingStatsId(
     address,

--- a/packages/stats-subgraph/src/utils/access/epochTradingStatsRecord.ts
+++ b/packages/stats-subgraph/src/utils/access/epochTradingStatsRecord.ts
@@ -11,22 +11,31 @@ import {
 export function generateAggregateTradingStatsId(
   address: string,
   epochType: string,
-  epochNumber: i32
+  epochNumber: i32,
+  collateral: string | null
 ): string {
-  return address + "-" + epochType + "-" + epochNumber.toString();
+  return address + "-" + epochType + "-" + epochNumber.toString() + collateral
+    ? "-" + collateral
+    : "";
 }
 
 export function createOrLoadEpochTradingStatsRecord(
   address: string,
   epochType: string,
   epochNumber: i32,
+  collateral: string | null,
   save: boolean
 ): EpochTradingStatsRecord {
   log.info(
     "[createOrLoadEpochTradingStatsRecord] address {}, epochType {}, epochNumber {}",
     [address, epochType.toString(), epochNumber.toString()]
   );
-  const id = generateAggregateTradingStatsId(address, epochType, epochNumber);
+  const id = generateAggregateTradingStatsId(
+    address,
+    epochType,
+    epochNumber,
+    collateral
+  );
   let epochTradingStatsRecord = EpochTradingStatsRecord.load(id);
   if (epochTradingStatsRecord == null) {
     epochTradingStatsRecord = new EpochTradingStatsRecord(id);
@@ -56,6 +65,7 @@ export function createOrLoadEpochTradingStatsRecord(
  * @dev This function is called when a user opens a trade
  */
 export class addOpenTradeStatsInput {
+  collateral: string | null;
   address: string;
   pairIndex: i32;
   groupIndex: i32;
@@ -67,6 +77,7 @@ export function addOpenTradeStats(data: addOpenTradeStatsInput): void {
   const pairIndex = data.pairIndex;
   const positionSize = data.positionSize;
   const timestamp = data.timestamp;
+  const collateral = data.collateral;
   log.info("[addOpenTradeStats] address {} pairIndex {}, positionSize {}", [
     address,
     pairIndex.toString(),
@@ -79,6 +90,7 @@ export function addOpenTradeStats(data: addOpenTradeStatsInput): void {
     address,
     EPOCH_TYPE.DAY,
     currentDayNumber,
+    collateral,
     false
   );
 
@@ -90,6 +102,7 @@ export function addOpenTradeStats(data: addOpenTradeStatsInput): void {
     address,
     EPOCH_TYPE.WEEK,
     currentWeekNumber,
+    collateral,
     false
   );
   _addOpenTradeStats(data, weeklyStats);
@@ -99,6 +112,7 @@ export function addOpenTradeStats(data: addOpenTradeStatsInput): void {
     PROTOCOL,
     EPOCH_TYPE.DAY,
     currentDayNumber,
+    collateral,
     false
   );
   _addOpenTradeStats(data, dailyProtocolStats);
@@ -108,12 +122,19 @@ export function addOpenTradeStats(data: addOpenTradeStatsInput): void {
     PROTOCOL,
     EPOCH_TYPE.WEEK,
     currentWeekNumber,
+    collateral,
     false
   );
   _addOpenTradeStats(data, weeklyProtocolStats);
 }
 
+function _handleCloseTradeCollateralStats(
+  data: addCloseTradeStatsInput,
+  timestamp: i32
+) {}
+
 export class addCloseTradeStatsInput {
+  collateral: string | null;
   address: string;
   pairIndex: i32;
   groupIndex: i32;

--- a/packages/stats-subgraph/src/utils/access/epochTradingStatsRecord.ts
+++ b/packages/stats-subgraph/src/utils/access/epochTradingStatsRecord.ts
@@ -6,6 +6,7 @@ import {
   EPOCH_TYPE,
   determineEpochNumber,
   PROTOCOL,
+  COLLATERALS,
 } from "../constants";
 
 export function generateAggregateTradingStatsId(
@@ -47,6 +48,9 @@ export function createOrLoadEpochTradingStatsRecord(
     epochTradingStatsRecord.address = address;
     epochTradingStatsRecord.epochType = epochType;
     epochTradingStatsRecord.epochNumber = epochNumber;
+    epochTradingStatsRecord.collateral = collateral
+      ? collateral
+      : COLLATERALS._ALL_;
     epochTradingStatsRecord.totalVolumePerGroup = [];
     epochTradingStatsRecord.totalBorrowingFees = ZERO_BD;
     epochTradingStatsRecord.pairsTraded = [];

--- a/packages/stats-subgraph/src/utils/access/epochTradingStatsRecord.ts
+++ b/packages/stats-subgraph/src/utils/access/epochTradingStatsRecord.ts
@@ -14,9 +14,14 @@ export function generateAggregateTradingStatsId(
   epochNumber: i32,
   collateral: string | null
 ): string {
-  return address + "-" + epochType + "-" + epochNumber.toString() + collateral
-    ? "-" + collateral
-    : "";
+  return (
+    address +
+    "-" +
+    epochType +
+    "-" +
+    epochNumber.toString() +
+    (collateral ? "-" + collateral : "")
+  );
 }
 
 export function createOrLoadEpochTradingStatsRecord(
@@ -128,11 +133,6 @@ export function addOpenTradeStats(data: addOpenTradeStatsInput): void {
   _addOpenTradeStats(data, weeklyProtocolStats);
 }
 
-function _handleCloseTradeCollateralStats(
-  data: addCloseTradeStatsInput,
-  timestamp: i32
-) {}
-
 export class addCloseTradeStatsInput {
   collateral: string | null;
   address: string;
@@ -148,6 +148,7 @@ export class addCloseTradeStatsInput {
  * @dev This function is called when a user closes a trade
  */
 export function addCloseTradeStats(data: addCloseTradeStatsInput): void {
+  const collateral = data.collateral;
   const address = data.address;
   const pairIndex = data.pairIndex;
   const positionSize = data.positionSize;
@@ -171,6 +172,7 @@ export function addCloseTradeStats(data: addCloseTradeStatsInput): void {
     address,
     EPOCH_TYPE.DAY,
     currentDayNumber,
+    collateral,
     false
   );
   _addCloseTradeStats(data, dailyStats);
@@ -181,6 +183,7 @@ export function addCloseTradeStats(data: addCloseTradeStatsInput): void {
     address,
     EPOCH_TYPE.WEEK,
     currentWeekNumber,
+    collateral,
     false
   );
   _addCloseTradeStats(data, weeklyStats);
@@ -190,6 +193,7 @@ export function addCloseTradeStats(data: addCloseTradeStatsInput): void {
     PROTOCOL,
     EPOCH_TYPE.DAY,
     currentDayNumber,
+    collateral,
     false
   );
   _addCloseTradeStats(data, dailyProtocolStats);
@@ -199,6 +203,7 @@ export function addCloseTradeStats(data: addCloseTradeStatsInput): void {
     PROTOCOL,
     EPOCH_TYPE.WEEK,
     currentWeekNumber,
+    collateral,
     false
   );
   _addCloseTradeStats(data, weeklyProtocolStats);
@@ -207,6 +212,7 @@ export function addCloseTradeStats(data: addCloseTradeStatsInput): void {
     address,
     currentWeekNumber,
     currentDayNumber,
+    collateral,
     data.pnl,
     data.pnlPercentage,
     data.groupIndex,
@@ -298,55 +304,86 @@ function _addCloseTradeStats(
 export function addBorrowingFeeStats(
   address: string,
   borrowingFee: BigDecimal,
-  timestamp: i32
+  timestamp: i32,
+  collateral: string | null
 ): EpochTradingStatsRecord[] {
-  return _addStats(address, borrowingFee, timestamp, "totalBorrowingFees");
+  return _addStats(
+    address,
+    borrowingFee,
+    timestamp,
+    collateral,
+    "totalBorrowingFees"
+  );
 }
 
 export function addGovFeeStats(
   address: string,
   govFee: BigDecimal,
-  timestamp: i32
+  timestamp: i32,
+  collateral: string | null
 ): EpochTradingStatsRecord[] {
-  return _addStats(address, govFee, timestamp, "totalGovFees");
+  return _addStats(address, govFee, timestamp, collateral, "totalGovFees");
 }
 
 export function addReferralFeeStats(
   address: string,
   referralFee: BigDecimal,
-  timestamp: i32
+  timestamp: i32,
+  collateral: string | null
 ): EpochTradingStatsRecord[] {
-  return _addStats(address, referralFee, timestamp, "totalReferralFees");
+  return _addStats(
+    address,
+    referralFee,
+    timestamp,
+    collateral,
+    "totalReferralFees"
+  );
 }
 
 export function addTriggerFeeStats(
   address: string,
   triggerFee: BigDecimal,
-  timestamp: i32
+  timestamp: i32,
+  collateral: string | null
 ): EpochTradingStatsRecord[] {
-  return _addStats(address, triggerFee, timestamp, "totalTriggerFees");
+  return _addStats(
+    address,
+    triggerFee,
+    timestamp,
+    collateral,
+    "totalTriggerFees"
+  );
 }
 
 export function addLpFeeStats(
   address: string,
   lpFee: BigDecimal,
-  timestamp: i32
+  timestamp: i32,
+  collateral: string | null
 ): EpochTradingStatsRecord[] {
-  return _addStats(address, lpFee, timestamp, "totalLpFees");
+  return _addStats(address, lpFee, timestamp, collateral, "totalLpFees");
 }
 
 export function addStakerFeeStats(
   address: string,
   stakerFee: BigDecimal,
-  timestamp: i32
+  timestamp: i32,
+  collateral: string | null
 ): EpochTradingStatsRecord[] {
-  return _addStats(address, stakerFee, timestamp, "totalStakerFees");
+  return _addStats(
+    address,
+    stakerFee,
+    timestamp,
+    collateral,
+    "totalStakerFees"
+  );
 }
 
 function _addStats(
   address: string,
   stat: BigDecimal,
   timestamp: i32,
+  collateral: string | null,
   statName: string
 ): EpochTradingStatsRecord[] {
   const currentDayNumber = determineEpochNumber(timestamp, EPOCH_TYPE.DAY);
@@ -356,6 +393,7 @@ function _addStats(
     address,
     EPOCH_TYPE.DAY,
     currentDayNumber,
+    collateral,
     false
   );
   dailyStats = _addStat(stat, statName, dailyStats);
@@ -364,6 +402,7 @@ function _addStats(
     address,
     EPOCH_TYPE.WEEK,
     currentWeekNumber,
+    collateral,
     false
   );
   weeklyStats = _addStat(stat, statName, weeklyStats);
@@ -372,6 +411,7 @@ function _addStats(
     PROTOCOL,
     EPOCH_TYPE.DAY,
     currentDayNumber,
+    collateral,
     false
   );
   dailyProtocolStats = _addStat(stat, statName, dailyProtocolStats);
@@ -380,6 +420,7 @@ function _addStats(
     PROTOCOL,
     EPOCH_TYPE.WEEK,
     currentWeekNumber,
+    collateral,
     false
   );
   weeklyProtocolStats = _addStat(stat, statName, weeklyProtocolStats);

--- a/packages/stats-subgraph/src/utils/constants.ts
+++ b/packages/stats-subgraph/src/utils/constants.ts
@@ -55,16 +55,10 @@ class Addresses {
   gnsPriceAggregator: string;
 }
 
-class CollateralAddresses {
+export class CollateralAddresses {
   DAI!: Addresses;
   ETH!: Addresses;
   ARB!: Addresses;
-}
-
-class NetworkAddresses {
-  "matic"!: CollateralAddresses;
-  "mumbai"!: CollateralAddresses;
-  "arbitrum-one"!: CollateralAddresses;
 }
 
 export const ARBITRUM_COLLATERALS: CollateralAddresses = {
@@ -119,12 +113,6 @@ export const MUMBAI_COLLATERALS: CollateralAddresses = {
     gnsTradingCallbacksV6_4_1: "",
     gnsPriceAggregator: "",
   },
-};
-
-export const NETWORK_ADDRESSES: NetworkAddresses = {
-  matic: POLYGON_COLLATERALS,
-  mumbai: MUMBAI_COLLATERALS,
-  "arbitrum-one": ARBITRUM_COLLATERALS,
 };
 
 class EpochTypes {
@@ -191,4 +179,50 @@ export function toDecimal(value: BigInt, decimals: i32): BigDecimal {
   return value
     .toBigDecimal()
     .div(exponentToBigDecimal(decimals).truncate(decimals));
+}
+
+export function getNetworkCollaterals(network: string): CollateralAddresses {
+  if (network === NETWORKS.ARBITRUM) {
+    return ARBITRUM_COLLATERALS;
+  }
+
+  if (network == NETWORKS.POLYGON) {
+    return POLYGON_COLLATERALS;
+  }
+
+  if (network === NETWORKS.MUMBAI) {
+    return MUMBAI_COLLATERALS;
+  }
+
+  throw new Error("Network not supported");
+}
+
+export function getNetworkCollateralAddressesFromNetwork(
+  networkCollaterals: CollateralAddresses,
+  collateral: string
+): Addresses {
+  if (collateral === COLLATERALS.DAI) {
+    return networkCollaterals.DAI;
+  }
+
+  if (collateral === COLLATERALS.ETH) {
+    return networkCollaterals.ETH;
+  }
+
+  if (collateral === COLLATERALS.ARB) {
+    return networkCollaterals.ARB;
+  }
+
+  throw new Error("Collateral not supported");
+}
+
+export function getNetworkCollateralAddresses(
+  network: string,
+  collateral: string
+): Addresses {
+  const collateralAddresses = getNetworkCollaterals(network);
+  return getNetworkCollateralAddressesFromNetwork(
+    collateralAddresses,
+    collateral
+  );
 }

--- a/packages/stats-subgraph/src/utils/constants.ts
+++ b/packages/stats-subgraph/src/utils/constants.ts
@@ -182,7 +182,7 @@ export function toDecimal(value: BigInt, decimals: i32): BigDecimal {
 }
 
 export function getNetworkCollaterals(network: string): CollateralAddresses {
-  if (network === NETWORKS.ARBITRUM) {
+  if (network == NETWORKS.ARBITRUM) {
     return ARBITRUM_COLLATERALS;
   }
 
@@ -190,7 +190,7 @@ export function getNetworkCollaterals(network: string): CollateralAddresses {
     return POLYGON_COLLATERALS;
   }
 
-  if (network === NETWORKS.MUMBAI) {
+  if (network == NETWORKS.MUMBAI) {
     return MUMBAI_COLLATERALS;
   }
 
@@ -201,15 +201,15 @@ export function getNetworkCollateralAddressesFromNetwork(
   networkCollaterals: CollateralAddresses,
   collateral: string
 ): Addresses {
-  if (collateral === COLLATERALS.DAI) {
+  if (collateral == COLLATERALS.DAI) {
     return networkCollaterals.DAI;
   }
 
-  if (collateral === COLLATERALS.ETH) {
+  if (collateral == COLLATERALS.ETH) {
     return networkCollaterals.ETH;
   }
 
-  if (collateral === COLLATERALS.ARB) {
+  if (collateral == COLLATERALS.ARB) {
     return networkCollaterals.ARB;
   }
 

--- a/packages/stats-subgraph/src/utils/constants.ts
+++ b/packages/stats-subgraph/src/utils/constants.ts
@@ -26,12 +26,14 @@ export const VOLUME_THRESHOLDS = [
 export const PROTOCOL = "protocol";
 
 class Collaterals {
+  _ALL_!: string;
   DAI!: string;
   ETH!: string;
   ARB!: string;
 }
 
 export const COLLATERALS: Collaterals = {
+  _ALL_: "_all_",
   DAI: "dai",
   ETH: "eth",
   ARB: "arb",

--- a/packages/stats-subgraph/src/utils/constants.ts
+++ b/packages/stats-subgraph/src/utils/constants.ts
@@ -24,9 +24,18 @@ export const VOLUME_THRESHOLDS = [
 ];
 
 export const PROTOCOL = "protocol";
-export const DAI = "dai";
-export const ETH = "eth";
-export const ARB = "arb";
+
+class Collaterals {
+  DAI!: string;
+  ETH!: string;
+  ARB!: string;
+}
+
+export const COLLATERALS: Collaterals = {
+  DAI: "dai",
+  ETH: "eth",
+  ARB: "arb",
+};
 
 class Networks {
   POLYGON!: string;
@@ -43,6 +52,7 @@ export const NETWORKS: Networks = {
 class Addresses {
   gnsPairsStorageV6!: string;
   gnsTradingCallbacksV6_4_1!: string;
+  gnsPriceAggregator: string;
 }
 
 class CollateralAddresses {
@@ -52,23 +62,26 @@ class CollateralAddresses {
 }
 
 class NetworkAddresses {
-  POLYGON!: CollateralAddresses;
-  MUMBAI!: CollateralAddresses;
-  ARBITRUM!: CollateralAddresses;
+  "matic"!: CollateralAddresses;
+  "mumbai"!: CollateralAddresses;
+  "arbitrum-one"!: CollateralAddresses;
 }
 
 export const ARBITRUM_COLLATERALS: CollateralAddresses = {
   DAI: {
     gnsPairsStorageV6: "0xf67Df2a4339eC1591615d94599081Dd037960d4b",
     gnsTradingCallbacksV6_4_1: "0x298a695906e16aeA0a184A2815A76eAd1a0b7522",
+    gnsPriceAggregator: "0x2e44a81701A8355E59B3204B4a9Fe8FC43CbE0C3",
   },
   ETH: {
     gnsPairsStorageV6: "",
     gnsTradingCallbacksV6_4_1: "",
+    gnsPriceAggregator: "",
   },
   ARB: {
     gnsPairsStorageV6: "",
     gnsTradingCallbacksV6_4_1: "",
+    gnsPriceAggregator: "",
   },
 };
 
@@ -76,14 +89,17 @@ export const POLYGON_COLLATERALS: CollateralAddresses = {
   DAI: {
     gnsPairsStorageV6: "0x6e5326e944F528c243B9Ca5d14fe5C9269a8c922",
     gnsTradingCallbacksV6_4_1: "0x82e59334da8C667797009BBe82473B55c7A6b311",
+    gnsPriceAggregator: "0x126F32723c5FC8DFEB17c46b7B7dD3dCd458A816",
   },
   ETH: {
     gnsPairsStorageV6: "",
     gnsTradingCallbacksV6_4_1: "",
+    gnsPriceAggregator: "",
   },
   ARB: {
     gnsPairsStorageV6: "",
     gnsTradingCallbacksV6_4_1: "",
+    gnsPriceAggregator: "",
   },
 };
 
@@ -91,21 +107,24 @@ export const MUMBAI_COLLATERALS: CollateralAddresses = {
   DAI: {
     gnsPairsStorageV6: "0x2b497ff78bA1F803141Ecca0F98eF3c5B5B64d26",
     gnsTradingCallbacksV6_4_1: "0xA7443A20B42f9156F7D9DB01e51523C42CAC8eCE",
+    gnsPriceAggregator: "0x5a284f0f52a8Ea4A33033EfB3Ffd723db9bbe312",
   },
   ETH: {
     gnsPairsStorageV6: "",
     gnsTradingCallbacksV6_4_1: "",
+    gnsPriceAggregator: "",
   },
   ARB: {
     gnsPairsStorageV6: "",
     gnsTradingCallbacksV6_4_1: "",
+    gnsPriceAggregator: "",
   },
 };
 
 export const NETWORK_ADDRESSES: NetworkAddresses = {
-  POLYGON: POLYGON_COLLATERALS,
-  MUMBAI: MUMBAI_COLLATERALS,
-  ARBITRUM: ARBITRUM_COLLATERALS,
+  matic: POLYGON_COLLATERALS,
+  mumbai: MUMBAI_COLLATERALS,
+  "arbitrum-one": ARBITRUM_COLLATERALS,
 };
 
 class EpochTypes {

--- a/packages/stats-subgraph/src/utils/constants.ts
+++ b/packages/stats-subgraph/src/utils/constants.ts
@@ -40,15 +40,21 @@ export const NETWORKS: Networks = {
   ARBITRUM: "arbitrum-one",
 };
 
-class NetworkAddresses {
+class Addresses {
   gnsPairsStorageV6!: string;
   gnsTradingCallbacksV6_4_1!: string;
 }
 
 class CollateralAddresses {
-  DAI!: NetworkAddresses;
-  ETH!: NetworkAddresses;
-  ARB!: NetworkAddresses;
+  DAI!: Addresses;
+  ETH!: Addresses;
+  ARB!: Addresses;
+}
+
+class NetworkAddresses {
+  POLYGON!: CollateralAddresses;
+  MUMBAI!: CollateralAddresses;
+  ARBITRUM!: CollateralAddresses;
 }
 
 export const ARBITRUM_COLLATERALS: CollateralAddresses = {
@@ -94,6 +100,12 @@ export const MUMBAI_COLLATERALS: CollateralAddresses = {
     gnsPairsStorageV6: "",
     gnsTradingCallbacksV6_4_1: "",
   },
+};
+
+export const NETWORK_ADDRESSES: NetworkAddresses = {
+  POLYGON: POLYGON_COLLATERALS,
+  MUMBAI: MUMBAI_COLLATERALS,
+  ARBITRUM: ARBITRUM_COLLATERALS,
 };
 
 class EpochTypes {

--- a/packages/stats-subgraph/src/utils/constants.ts
+++ b/packages/stats-subgraph/src/utils/constants.ts
@@ -4,6 +4,10 @@ export const ZERO_BD = BigDecimal.fromString("0");
 export const ONE_BD = BigDecimal.fromString("1");
 export const DAI_DECIMALS = 18;
 export const DAI_DECIMALS_BD = exponentToBigDecimal(DAI_DECIMALS);
+export const ARB_DECIMALS = 18;
+export const ARB_DECIMALS_BD = exponentToBigDecimal(ARB_DECIMALS);
+export const ETH_DECIMALS = 18;
+export const ETH_DECIMALS_BD = exponentToBigDecimal(ETH_DECIMALS);
 export const PRECISION_DECIMALS = 10;
 export const PRECISION_DECIMALS_BD = exponentToBigDecimal(PRECISION_DECIMALS);
 
@@ -20,6 +24,9 @@ export const VOLUME_THRESHOLDS = [
 ];
 
 export const PROTOCOL = "protocol";
+export const DAI = "dai";
+export const ETH = "eth";
+export const ARB = "arb";
 
 class Networks {
   POLYGON!: string;
@@ -35,18 +42,58 @@ export const NETWORKS: Networks = {
 
 class NetworkAddresses {
   gnsPairsStorageV6!: string;
+  gnsTradingCallbacksV6_4_1!: string;
 }
 
-export const ARBITRUM_ADDRESSES: NetworkAddresses = {
-  gnsPairsStorageV6: "0xf67Df2a4339eC1591615d94599081Dd037960d4b",
+class CollateralAddresses {
+  DAI!: NetworkAddresses;
+  ETH!: NetworkAddresses;
+  ARB!: NetworkAddresses;
+}
+
+export const ARBITRUM_COLLATERALS: CollateralAddresses = {
+  DAI: {
+    gnsPairsStorageV6: "0xf67Df2a4339eC1591615d94599081Dd037960d4b",
+    gnsTradingCallbacksV6_4_1: "0x298a695906e16aeA0a184A2815A76eAd1a0b7522",
+  },
+  ETH: {
+    gnsPairsStorageV6: "",
+    gnsTradingCallbacksV6_4_1: "",
+  },
+  ARB: {
+    gnsPairsStorageV6: "",
+    gnsTradingCallbacksV6_4_1: "",
+  },
 };
 
-export const POLYGON_ADDRESSES: NetworkAddresses = {
-  gnsPairsStorageV6: "0x6e5326e944F528c243B9Ca5d14fe5C9269a8c922",
+export const POLYGON_COLLATERALS: CollateralAddresses = {
+  DAI: {
+    gnsPairsStorageV6: "0x6e5326e944F528c243B9Ca5d14fe5C9269a8c922",
+    gnsTradingCallbacksV6_4_1: "0x82e59334da8C667797009BBe82473B55c7A6b311",
+  },
+  ETH: {
+    gnsPairsStorageV6: "",
+    gnsTradingCallbacksV6_4_1: "",
+  },
+  ARB: {
+    gnsPairsStorageV6: "",
+    gnsTradingCallbacksV6_4_1: "",
+  },
 };
 
-export const MUMBAI_ADDRESSES: NetworkAddresses = {
-  gnsPairsStorageV6: "0x2b497ff78bA1F803141Ecca0F98eF3c5B5B64d26",
+export const MUMBAI_COLLATERALS: CollateralAddresses = {
+  DAI: {
+    gnsPairsStorageV6: "0x2b497ff78bA1F803141Ecca0F98eF3c5B5B64d26",
+    gnsTradingCallbacksV6_4_1: "0xA7443A20B42f9156F7D9DB01e51523C42CAC8eCE",
+  },
+  ETH: {
+    gnsPairsStorageV6: "",
+    gnsTradingCallbacksV6_4_1: "",
+  },
+  ARB: {
+    gnsPairsStorageV6: "",
+    gnsTradingCallbacksV6_4_1: "",
+  },
 };
 
 class EpochTypes {

--- a/packages/stats-subgraph/src/utils/contract/GNSPairsStorageV6/index.ts
+++ b/packages/stats-subgraph/src/utils/contract/GNSPairsStorageV6/index.ts
@@ -6,20 +6,18 @@ import {
 } from "@graphprotocol/graph-ts";
 import {
   NETWORKS,
-  ARBITRUM_ADDRESSES,
-  POLYGON_ADDRESSES,
-  MUMBAI_ADDRESSES,
+  ARBITRUM_COLLATERALS,
+  POLYGON_COLLATERALS,
+  MUMBAI_COLLATERALS,
 } from "../../constants";
 import { GNSPairsStorageV6 } from "../../../types/GNSTradingCallbacksV6_4_1/GNSPairsStorageV6";
 import { convertPercentage } from "..";
 
-export function getPairsStorageContract(): GNSPairsStorageV6 {
-  const config =
-    dataSource.network() == NETWORKS.ARBITRUM
-      ? ARBITRUM_ADDRESSES
-      : dataSource.network() == NETWORKS.POLYGON
-      ? POLYGON_ADDRESSES
-      : MUMBAI_ADDRESSES;
+export function getPairsStorageContract(
+  network: String,
+  collateral: String
+): GNSPairsStorageV6 {
+  const config = NETWORKS[+network][+collateral];
 
   if (config == null) {
     throw new Error("Network not supported");
@@ -31,8 +29,12 @@ export function getPairsStorageContract(): GNSPairsStorageV6 {
  * @param pairIndex
  * @returns totalOpenFeeP = pairOpenFeeP * 2 + pairNftLimitOrderFeeP
  */
-export function getTotalOpenFeeP(pairIndex: BigInt): BigDecimal {
-  const pairsStorageContract = getPairsStorageContract();
+export function getTotalOpenFeeP(
+  network: String,
+  collateral: String,
+  pairIndex: BigInt
+): BigDecimal {
+  const pairsStorageContract = getPairsStorageContract(network, collateral);
   const pairOpenFeeP = convertPercentage(
     pairsStorageContract.pairOpenFeeP(pairIndex)
   );
@@ -51,10 +53,12 @@ export function getTotalOpenFeeP(pairIndex: BigInt): BigDecimal {
  * @returns totalCloseFeeP = pairCloseFeeP + pairNftLimitOrderFeeP
  */
 export function getTotalCloseFeeP(
+  network: String,
+  collateral: String,
   pairIndex: BigInt,
   isLiq: boolean
 ): BigDecimal {
-  const pairsStorageContract = getPairsStorageContract();
+  const pairsStorageContract = getPairsStorageContract(network, collateral);
   const pairCloseFeeP = convertPercentage(
     pairsStorageContract.pairCloseFeeP(pairIndex)
   );
@@ -75,7 +79,11 @@ export function getLiquidationFeeP(pairIndex: BigInt): BigDecimal {
   return BigDecimal.fromString("5");
 }
 
-export function getGroupIndex(pairIndex: BigInt): BigInt {
-  const pairsStorageContract = getPairsStorageContract();
+export function getGroupIndex(
+  network: String,
+  collateral: String,
+  pairIndex: BigInt
+): BigInt {
+  const pairsStorageContract = getPairsStorageContract(network, collateral);
   return pairsStorageContract.pairs(pairIndex).getGroupIndex();
 }

--- a/packages/stats-subgraph/src/utils/contract/GNSPairsStorageV6/index.ts
+++ b/packages/stats-subgraph/src/utils/contract/GNSPairsStorageV6/index.ts
@@ -1,5 +1,5 @@
 import { Address, BigInt, BigDecimal } from "@graphprotocol/graph-ts";
-import { NETWORK_ADDRESSES } from "../../constants";
+import { getNetworkCollateralAddresses } from "../../constants";
 import { GNSPairsStorageV6 } from "../../../types/GNSTradingCallbacksV6_4_1/GNSPairsStorageV6";
 import { convertPercentage } from "..";
 
@@ -7,12 +7,17 @@ export function getPairsStorageContract(
   network: string,
   collateral: string
 ): GNSPairsStorageV6 {
-  const config = NETWORK_ADDRESSES[network][collateral];
+  const collateralAddresses = getNetworkCollateralAddresses(
+    network,
+    collateral
+  );
 
-  if (config == null) {
+  if (collateralAddresses == null) {
     throw new Error("Network not supported");
   }
-  return GNSPairsStorageV6.bind(Address.fromString(config.gnsPairsStorageV6));
+  return GNSPairsStorageV6.bind(
+    Address.fromString(collateralAddresses.gnsPairsStorageV6)
+  );
 }
 
 /**

--- a/packages/stats-subgraph/src/utils/contract/GNSPairsStorageV6/index.ts
+++ b/packages/stats-subgraph/src/utils/contract/GNSPairsStorageV6/index.ts
@@ -1,15 +1,5 @@
-import {
-  Address,
-  dataSource,
-  BigInt,
-  BigDecimal,
-} from "@graphprotocol/graph-ts";
-import {
-  NETWORKS,
-  ARBITRUM_COLLATERALS,
-  POLYGON_COLLATERALS,
-  MUMBAI_COLLATERALS,
-} from "../../constants";
+import { Address, BigInt, BigDecimal } from "@graphprotocol/graph-ts";
+import { NETWORK_ADDRESSES } from "../../constants";
 import { GNSPairsStorageV6 } from "../../../types/GNSTradingCallbacksV6_4_1/GNSPairsStorageV6";
 import { convertPercentage } from "..";
 
@@ -17,7 +7,7 @@ export function getPairsStorageContract(
   network: string,
   collateral: string
 ): GNSPairsStorageV6 {
-  const config = NETWORKS[+network][+collateral];
+  const config = NETWORK_ADDRESSES[network][collateral];
 
   if (config == null) {
     throw new Error("Network not supported");

--- a/packages/stats-subgraph/src/utils/contract/GNSPairsStorageV6/index.ts
+++ b/packages/stats-subgraph/src/utils/contract/GNSPairsStorageV6/index.ts
@@ -14,8 +14,8 @@ import { GNSPairsStorageV6 } from "../../../types/GNSTradingCallbacksV6_4_1/GNSP
 import { convertPercentage } from "..";
 
 export function getPairsStorageContract(
-  network: String,
-  collateral: String
+  network: string,
+  collateral: string
 ): GNSPairsStorageV6 {
   const config = NETWORKS[+network][+collateral];
 
@@ -30,8 +30,8 @@ export function getPairsStorageContract(
  * @returns totalOpenFeeP = pairOpenFeeP * 2 + pairNftLimitOrderFeeP
  */
 export function getTotalOpenFeeP(
-  network: String,
-  collateral: String,
+  network: string,
+  collateral: string,
   pairIndex: BigInt
 ): BigDecimal {
   const pairsStorageContract = getPairsStorageContract(network, collateral);
@@ -53,8 +53,8 @@ export function getTotalOpenFeeP(
  * @returns totalCloseFeeP = pairCloseFeeP + pairNftLimitOrderFeeP
  */
 export function getTotalCloseFeeP(
-  network: String,
-  collateral: String,
+  network: string,
+  collateral: string,
   pairIndex: BigInt,
   isLiq: boolean
 ): BigDecimal {
@@ -80,8 +80,8 @@ export function getLiquidationFeeP(pairIndex: BigInt): BigDecimal {
 }
 
 export function getGroupIndex(
-  network: String,
-  collateral: String,
+  network: string,
+  collateral: string,
   pairIndex: BigInt
 ): BigInt {
   const pairsStorageContract = getPairsStorageContract(network, collateral);

--- a/packages/stats-subgraph/src/utils/contract/GNSPriceAggregator/index.ts
+++ b/packages/stats-subgraph/src/utils/contract/GNSPriceAggregator/index.ts
@@ -1,0 +1,43 @@
+import { Address, BigDecimal } from "@graphprotocol/graph-ts";
+import { GNSPriceAggregator } from "../../../types/GNSTradingCallbacksV6_4_1/GNSPriceAggregator";
+import { IChainlinkFeed } from "../../../types/GNSTradingCallbacksV6_4_1/IChainlinkFeed";
+import { NETWORK_ADDRESSES } from "../../constants";
+
+export function getPriceAggregatorContract(
+  network: string,
+  collateral: string
+): GNSPriceAggregator {
+  const config = NETWORK_ADDRESSES[network][collateral];
+
+  if (config == null) {
+    throw new Error("Network not supported");
+  }
+  return GNSPriceAggregator.bind(Address.fromString(config.gnsPriceAggregator));
+}
+
+// For backwards compatibility this function returns 1 if the price feed is not found
+// @todo once multicollat is deployed to mainnet, this function should throw an error
+export function getCollateralPrice(
+  network: string,
+  collateral: string
+): BigDecimal {
+  const priceAggregator = getPriceAggregatorContract(network, collateral);
+  const priceFeed = priceAggregator.try_collateralPriceFeed();
+  if (priceFeed.reverted) {
+    console.warn("Price feed not found");
+    return BigDecimal.fromString("1");
+  }
+  const feed = IChainlinkFeed.bind(priceFeed.value);
+  const price = feed.try_latestRoundData();
+  if (price.reverted) {
+    console.warn("Latest round data missing");
+    return BigDecimal.fromString("1");
+  }
+
+  const precision = priceAggregator.try_getCollateralPrecision();
+
+  return price.value
+    .getValue1()
+    .toBigDecimal()
+    .div(precision.value.toBigDecimal());
+}

--- a/packages/stats-subgraph/src/utils/contract/GNSPriceAggregator/index.ts
+++ b/packages/stats-subgraph/src/utils/contract/GNSPriceAggregator/index.ts
@@ -1,13 +1,13 @@
-import { Address, BigDecimal } from "@graphprotocol/graph-ts";
+import { Address, BigDecimal, log } from "@graphprotocol/graph-ts";
 import { GNSPriceAggregator } from "../../../types/GNSTradingCallbacksV6_4_1/GNSPriceAggregator";
 import { IChainlinkFeed } from "../../../types/GNSTradingCallbacksV6_4_1/IChainlinkFeed";
-import { NETWORK_ADDRESSES } from "../../constants";
+import { getNetworkCollateralAddresses } from "../../constants";
 
 export function getPriceAggregatorContract(
   network: string,
   collateral: string
 ): GNSPriceAggregator {
-  const config = NETWORK_ADDRESSES[network][collateral];
+  const config = getNetworkCollateralAddresses(network, collateral);
 
   if (config == null) {
     throw new Error("Network not supported");
@@ -24,13 +24,13 @@ export function getCollateralPrice(
   const priceAggregator = getPriceAggregatorContract(network, collateral);
   const priceFeed = priceAggregator.try_collateralPriceFeed();
   if (priceFeed.reverted) {
-    console.warn("Price feed not found");
+    // log.warn("Price feed not found");
     return BigDecimal.fromString("1");
   }
   const feed = IChainlinkFeed.bind(priceFeed.value);
   const price = feed.try_latestRoundData();
   if (price.reverted) {
-    console.warn("Latest round data missing");
+    // log.warn("Latest round data missing");
     return BigDecimal.fromString("1");
   }
 

--- a/packages/stats-subgraph/src/utils/contract/index.ts
+++ b/packages/stats-subgraph/src/utils/contract/index.ts
@@ -2,8 +2,8 @@ import { BigInt, BigDecimal } from "@graphprotocol/graph-ts";
 import {
   COLLATERALS,
   DAI_DECIMALS_BD,
-  NETWORK_ADDRESSES,
   PRECISION_DECIMALS_BD,
+  getNetworkCollaterals,
 } from "../constants";
 export * from "./GNSPairsStorageV6";
 
@@ -33,15 +33,16 @@ export function getCollateralFromCallbacksAddress(
   network: string,
   address: string
 ): string {
-  if (NETWORK_ADDRESSES[network][COLLATERALS.DAI] == address) {
+  const collateralAddresses = getNetworkCollaterals(network);
+  if (collateralAddresses.DAI.gnsTradingCallbacksV6_4_1 == address) {
     return COLLATERALS.DAI;
   }
 
-  if (NETWORK_ADDRESSES[network][COLLATERALS.ETH] == address) {
+  if (collateralAddresses.ETH.gnsTradingCallbacksV6_4_1 == address) {
     return COLLATERALS.ETH;
   }
 
-  if (NETWORK_ADDRESSES[network][COLLATERALS.ARB] == address) {
+  if (collateralAddresses.ARB.gnsTradingCallbacksV6_4_1 == address) {
     return COLLATERALS.ARB;
   }
 

--- a/packages/stats-subgraph/src/utils/contract/index.ts
+++ b/packages/stats-subgraph/src/utils/contract/index.ts
@@ -17,7 +17,10 @@ export function convertPercentageToDecimal(percentage: BigInt): BigDecimal {
     .div(BigDecimal.fromString("100"));
 }
 
-export function getCollateralFromAddress(address: string): string {
+export function getCollateralFromCallbacksAddress(
+  network: string,
+  address: string
+): string {
   if (address == "0x0000") {
   }
 }

--- a/packages/stats-subgraph/src/utils/contract/index.ts
+++ b/packages/stats-subgraph/src/utils/contract/index.ts
@@ -34,17 +34,23 @@ export function getCollateralFromCallbacksAddress(
   address: string
 ): string {
   const collateralAddresses = getNetworkCollaterals(network);
-  if (collateralAddresses.DAI.gnsTradingCallbacksV6_4_1 == address) {
+  if (
+    collateralAddresses.DAI.gnsTradingCallbacksV6_4_1.toLowerCase() == address
+  ) {
     return COLLATERALS.DAI;
   }
 
-  if (collateralAddresses.ETH.gnsTradingCallbacksV6_4_1 == address) {
+  if (
+    collateralAddresses.ETH.gnsTradingCallbacksV6_4_1.toLowerCase() == address
+  ) {
     return COLLATERALS.ETH;
   }
 
-  if (collateralAddresses.ARB.gnsTradingCallbacksV6_4_1 == address) {
+  if (
+    collateralAddresses.ARB.gnsTradingCallbacksV6_4_1.toLowerCase() == address
+  ) {
     return COLLATERALS.ARB;
   }
 
-  throw new Error("Collateral not supported");
+  throw new Error("Callbacks address not found " + address);
 }

--- a/packages/stats-subgraph/src/utils/contract/index.ts
+++ b/packages/stats-subgraph/src/utils/contract/index.ts
@@ -16,3 +16,8 @@ export function convertPercentageToDecimal(percentage: BigInt): BigDecimal {
     .div(PRECISION_DECIMALS_BD)
     .div(BigDecimal.fromString("100"));
 }
+
+export function getCollateralFromAddress(address: string): string {
+  if (address == "0x0000") {
+  }
+}

--- a/packages/stats-subgraph/src/utils/contract/index.ts
+++ b/packages/stats-subgraph/src/utils/contract/index.ts
@@ -1,8 +1,13 @@
 import { BigInt, BigDecimal } from "@graphprotocol/graph-ts";
-import { DAI_DECIMALS_BD, PRECISION_DECIMALS_BD } from "../constants";
+import {
+  COLLATERALS,
+  DAI_DECIMALS_BD,
+  NETWORK_ADDRESSES,
+  PRECISION_DECIMALS_BD,
+} from "../constants";
 export * from "./GNSPairsStorageV6";
 
-export function convertDai(dai: BigInt): BigDecimal {
+export function convertDaiToDecimal(dai: BigInt): BigDecimal {
   return dai.toBigDecimal().div(DAI_DECIMALS_BD);
 }
 
@@ -17,10 +22,28 @@ export function convertPercentageToDecimal(percentage: BigInt): BigDecimal {
     .div(BigDecimal.fromString("100"));
 }
 
+export function convertCollateralToUsd(
+  amount: BigDecimal,
+  collateralToUsd: BigDecimal
+): BigDecimal {
+  return amount.times(collateralToUsd);
+}
+
 export function getCollateralFromCallbacksAddress(
   network: string,
   address: string
 ): string {
-  if (address == "0x0000") {
+  if (NETWORK_ADDRESSES[network][COLLATERALS.DAI] == address) {
+    return COLLATERALS.DAI;
   }
+
+  if (NETWORK_ADDRESSES[network][COLLATERALS.ETH] == address) {
+    return COLLATERALS.ETH;
+  }
+
+  if (NETWORK_ADDRESSES[network][COLLATERALS.ARB] == address) {
+    return COLLATERALS.ARB;
+  }
+
+  throw new Error("Collateral not supported");
 }

--- a/packages/stats-subgraph/subgraph.yaml
+++ b/packages/stats-subgraph/subgraph.yaml
@@ -6,11 +6,11 @@ schema:
 dataSources:
   - kind: ethereum
     name: GNSTradingCallbacksV6_4_1
-    network: 'arbitrum-one'
+    network: 'matic'
     source:
-      address: '0x298a695906e16aeA0a184A2815A76eAd1a0b7522'
+      address: '0x82e59334da8C667797009BBe82473B55c7A6b311'
       abi: GNSTradingCallbacksV6_4_1
-      startBlock: 136035360
+      startBlock: 48152959
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6

--- a/packages/stats-subgraph/subgraph.yaml
+++ b/packages/stats-subgraph/subgraph.yaml
@@ -6,11 +6,11 @@ schema:
 dataSources:
   - kind: ethereum
     name: GNSTradingCallbacksV6_4_1
-    network: 'matic'
+    network: 'arbitrum-one'
     source:
-      address: '0x82e59334da8C667797009BBe82473B55c7A6b311'
+      address: '0x298a695906e16aeA0a184A2815A76eAd1a0b7522'
       abi: GNSTradingCallbacksV6_4_1
-      startBlock: 48152959
+      startBlock: 136035360
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6

--- a/packages/stats-subgraph/subgraph.yaml
+++ b/packages/stats-subgraph/subgraph.yaml
@@ -6,9 +6,9 @@ schema:
 dataSources:
   - kind: ethereum
     name: GNSTradingCallbacksV6_4_1
-    network: 'mumbai'
+    network: "mumbai"
     source:
-      address: '0xA7443A20B42f9156F7D9DB01e51523C42CAC8eCE'
+      address: "0xA7443A20B42f9156F7D9DB01e51523C42CAC8eCE"
       abi: GNSTradingCallbacksV6_4_1
       startBlock: 40700000
     mapping:
@@ -22,6 +22,10 @@ dataSources:
           file: ./abis/GNSTradingCallbacksV6_4_1.json
         - name: GNSPairsStorageV6
           file: ./abis/GNSPairsStorageV6.json
+        - name: GNSPriceAggregator
+          file: ./abis/GNSPriceAggregator.json
+        - name: IChainlinkFeed
+          file: ./abis/IChainlinkFeed.json
       eventHandlers:
         - event: MarketExecuted(indexed uint256,(address,uint256,uint256,uint256,uint256,uint256,bool,uint256,uint256,uint256),bool,uint256,uint256,uint256,int256,uint256)
           handler: handleMarketExecuted

--- a/packages/stats-subgraph/subgraph.yaml
+++ b/packages/stats-subgraph/subgraph.yaml
@@ -6,11 +6,11 @@ schema:
 dataSources:
   - kind: ethereum
     name: GNSTradingCallbacksV6_4_1
-    network: "mumbai"
+    network: 'matic'
     source:
-      address: "0xA7443A20B42f9156F7D9DB01e51523C42CAC8eCE"
+      address: '0x82e59334da8C667797009BBe82473B55c7A6b311'
       abi: GNSTradingCallbacksV6_4_1
-      startBlock: 40700000
+      startBlock: 48152959
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6

--- a/packages/stats-subgraph/subgraph.yaml.mustache
+++ b/packages/stats-subgraph/subgraph.yaml.mustache
@@ -22,6 +22,10 @@ dataSources:
           file: ./abis/GNSTradingCallbacksV6_4_1.json
         - name: GNSPairsStorageV6
           file: ./abis/GNSPairsStorageV6.json
+        - name: GNSPriceAggregator
+          file: ./abis/GNSPriceAggregator.json
+        - name: IChainlinkFeed
+          file: ./abis/IChainlinkFeed.json
       eventHandlers:
         - event: MarketExecuted(indexed uint256,(address,uint256,uint256,uint256,uint256,uint256,bool,uint256,uint256,uint256),bool,uint256,uint256,uint256,int256,uint256)
           handler: handleMarketExecuted

--- a/packages/stats-subgraph/subgraph.yaml.mustache
+++ b/packages/stats-subgraph/subgraph.yaml.mustache
@@ -8,9 +8,9 @@ dataSources:
     name: GNSTradingCallbacksV6_4_1
     network: '{{network}}'
     source:
-      address: '{{gnsTradingCallbacksV6_4_1.address}}'
+      address: '{{DAI.gnsTradingCallbacksV6_4_1.address}}'
       abi: GNSTradingCallbacksV6_4_1
-      startBlock: {{gnsTradingCallbacksV6_4_1.startBlock}}
+      startBlock: {{DAI.gnsTradingCallbacksV6_4_1.startBlock}}
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.5


### PR DESCRIPTION
* Cross-collateral entities - ID: address-epoch-epochNumber - normalized to usd for all collaterals using chainlink price feeds from price aggregator. These are backwards compatible - no changes downstream required.
* Collateral specific entities - ID: address-epoch-epochNumber-collateral - same as existing behavior, denominated in collateral. These won't be used for current stip proposal but do allow us to run collateral specific rewards or extend to support different weights (I.e. incentivize arb more than other collaterals to build tvl).