### PR TITLE
Bugfix reward farming edge case

### DIFF
--- a/packages/stats-subgraph/src/handlers/GNSTradingCallbacksV6_4_1/index.ts
+++ b/packages/stats-subgraph/src/handlers/GNSTradingCallbacksV6_4_1/index.ts
@@ -5,6 +5,8 @@ import {
   dataSource,
   ethereum,
   Address,
+  crypto,
+  ByteArray,
 } from "@graphprotocol/graph-ts";
 import {
   addBorrowingFeeStats,
@@ -34,6 +36,35 @@ import {
   isTraderReferredByAggregator,
 } from "../../utils/contract";
 import { getCollateralPrice } from "../../utils/contract/GNSPriceAggregator";
+import { NETWORKS } from "../../utils/constants";
+
+const startArbitrumBlock = 167165039; // Jan-05-2024 12:00:00 AM +UTC
+function wasTradeOpenCanceled(receipt: ethereum.TransactionReceipt): boolean {
+  // Only start checking for canceled trades at this block on Arb where there are active rewards
+  if (
+    receipt.blockNumber.toI32() < startArbitrumBlock &&
+    dataSource.network() == NETWORKS.ARBITRUM
+  ) {
+    return false;
+  }
+  const events = receipt.logs;
+  for (let i = 0; i < events.length; i++) {
+    const event = events[i];
+    if (
+      event.topics[0].toHexString() ==
+      crypto
+        .keccak256(
+          ByteArray.fromUTF8(
+            "MarketOpenCanceled(uint256,address,uint256,uint8)"
+          )
+        )
+        .toHexString()
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
 
 class CollateralDetails {
   collateral: string;
@@ -185,6 +216,14 @@ export function handleGovFeeCharged(event: GovFeeCharged): void {
     )
   ) {
     log.info("[handleMarketExecuted] Aggregator referral {}", [
+      event.transaction.hash.toHexString(),
+    ]);
+    return;
+  }
+
+  // Confirm the trade was not canceled
+  if (wasTradeOpenCanceled(event.receipt as ethereum.TransactionReceipt)) {
+    log.info("[handleGovFeeCharged] Trade canceled {}", [
       event.transaction.hash.toHexString(),
     ]);
     return;

--- a/packages/stats-subgraph/src/handlers/GNSTradingCallbacksV6_4_1/index.ts
+++ b/packages/stats-subgraph/src/handlers/GNSTradingCallbacksV6_4_1/index.ts
@@ -221,22 +221,23 @@ export function handleGovFeeCharged(event: GovFeeCharged): void {
     return;
   }
 
-  // Confirm the trade was not canceled
+  log.info("[handleGovFeeCharged] {}", [event.transaction.hash.toHexString()]);
+  addGovFeeStats(trader, govFee, timestamp, collateralDetails.collateral);
+
+  // Calculate and add normalized stats
+  const govFeeUsd = govFee.times(collateralDetails.collateralToUsd);
+  addGovFeeStats(trader, govFeeUsd, timestamp, null);
+
+  // Confirm the trade was not canceled before adding points
   if (wasTradeOpenCanceled(event.receipt as ethereum.TransactionReceipt)) {
-    log.info("[handleGovFeeCharged] Trade canceled {}", [
+    log.info("[handleGovFeeCharged] Trade canceled, not adding points {}", [
       event.transaction.hash.toHexString(),
     ]);
     return;
   }
 
-  log.info("[handleGovFeeCharged] {}", [event.transaction.hash.toHexString()]);
-  addGovFeeStats(trader, govFee, timestamp, collateralDetails.collateral);
-  updateFeeBasedPoints(trader, govFee, timestamp, collateralDetails.collateral);
-
-  // Calculate and add normalized stats
-  const govFeeUsd = govFee.times(collateralDetails.collateralToUsd);
-  addGovFeeStats(trader, govFeeUsd, timestamp, null);
   updateFeeBasedPoints(trader, govFeeUsd, timestamp, null);
+  updateFeeBasedPoints(trader, govFee, timestamp, collateralDetails.collateral);
 }
 
 export function handleReferralFeeCharged(event: ReferralFeeCharged): void {

--- a/packages/stats-subgraph/src/handlers/GNSTradingCallbacksV6_4_1/index.ts
+++ b/packages/stats-subgraph/src/handlers/GNSTradingCallbacksV6_4_1/index.ts
@@ -39,6 +39,11 @@ import { getCollateralPrice } from "../../utils/contract/GNSPriceAggregator";
 import { NETWORKS } from "../../utils/constants";
 
 const startArbitrumBlock = 167165039; // Jan-05-2024 12:00:00 AM +UTC
+const eventHash = crypto
+  .keccak256(
+    ByteArray.fromUTF8("MarketOpenCanceled(uint256,address,uint256,uint8)")
+  )
+  .toHexString();
 function wasTradeOpenCanceled(receipt: ethereum.TransactionReceipt): boolean {
   // Only start checking for canceled trades at this block on Arb where there are active rewards
   if (
@@ -50,16 +55,7 @@ function wasTradeOpenCanceled(receipt: ethereum.TransactionReceipt): boolean {
   const events = receipt.logs;
   for (let i = 0; i < events.length; i++) {
     const event = events[i];
-    if (
-      event.topics[0].toHexString() ==
-      crypto
-        .keccak256(
-          ByteArray.fromUTF8(
-            "MarketOpenCanceled(uint256,address,uint256,uint8)"
-          )
-        )
-        .toHexString()
-    ) {
+    if (event.topics[0].toHexString() == eventHash) {
       return true;
     }
   }

--- a/packages/stats-subgraph/subgraph.yaml
+++ b/packages/stats-subgraph/subgraph.yaml
@@ -6,14 +6,14 @@ schema:
 dataSources:
   - kind: ethereum
     name: GNSTradingCallbacksV6_4_1
-    network: 'arbitrum-one'
+    network: 'matic'
     source:
-      address: '0x298a695906e16aeA0a184A2815A76eAd1a0b7522'
+      address: '0x82e59334da8C667797009BBe82473B55c7A6b311'
       abi: GNSTradingCallbacksV6_4_1
-      startBlock: 162235360
+      startBlock: 52171500
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - AggregateTradingStats
@@ -37,6 +37,7 @@ dataSources:
           handler: handleBorrowingFeeCharged
         - event: GovFeeCharged(indexed address,uint256,bool)
           handler: handleGovFeeCharged
+          receipt: true
         - event: ReferralFeeCharged(indexed address,uint256)
           handler: handleReferralFeeCharged
         - event: TriggerFeeCharged(indexed address,uint256)

--- a/packages/stats-subgraph/subgraph.yaml.mustache
+++ b/packages/stats-subgraph/subgraph.yaml.mustache
@@ -13,7 +13,7 @@ dataSources:
       startBlock: {{DAI.gnsTradingCallbacksV6_4_1.startBlock}}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.5
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - AggregateTradingStats
@@ -37,6 +37,7 @@ dataSources:
           handler: handleBorrowingFeeCharged
         - event: GovFeeCharged(indexed address,uint256,bool)
           handler: handleGovFeeCharged
+          receipt: true
         - event: ReferralFeeCharged(indexed address,uint256)
           handler: handleReferralFeeCharged
         - event: TriggerFeeCharged(indexed address,uint256)


### PR DESCRIPTION
* Add check to `handleGovFees` to determine if a trade had been canceled
* Skip all point additions in this case
* Only start on current epoch (Jan 5 00:00 UTC) for Arb

# Testing
Deployed to Polygon and tested -- cancel was captured:
```
[handleGovFeeCharged] Trade canceled 0x0f5279e82567458b0934629a94c12ca1779c0b4020c6f0981fa038de983a24a2, data_source: GNSTradingCallbacksV6_4_1, component: UserMapping
```
