### PR TITLE
Add pnl % eligibility requirement and additional referrals

### DIFF
--- a/packages/graph-client/.graphclientrc.yml
+++ b/packages/graph-client/.graphclientrc.yml
@@ -2,7 +2,7 @@ sources:
   - name: gtrade-stats
     handler:
       graphql:
-        endpoint: https://api.thegraph.com/subgraphs/name/gainsnetwork-org/{context.graphName:gtrade-stats-mumbai}
+        endpoint: https://api.thegraph.com/subgraphs/name/gainsnetwork-org/{context.graphName:gtrade-stats-arbitrum-v2}
         retry: 3
     transforms:
       - autoPagination:
@@ -12,7 +12,7 @@ sources:
   - name: gtoken
     handler:
       graphql:
-        endpoint: https://api.thegraph.com/subgraphs/name/thebuidler/{context.graphName:gtoken-arbitrum}
+        endpoint: https://api.thegraph.com/subgraphs/name/thebuidler/{context.graphName:gtoken-arbitrum-mc1}
         retry: 3
 
 additionalTypeDefs: |

--- a/packages/graph-client/helpers/config.ts
+++ b/packages/graph-client/helpers/config.ts
@@ -1,11 +1,11 @@
 export const GTOKEN_SUBGRAPH = {
-  137: "gtoken-polygon",
-  42161: "gtoken-arbitrum",
-  80001: "gtoken-mumbai",
+  137: "gtoken-polygon-mc1",
+  42161: "gtoken-arbitrum-mc1",
+  80001: "gtoken-mumbai-mc1",
 };
 
 export const STATS_SUBGRAPH = {
-  137: "gtrade-stats-polygon",
-  42161: "gtrade-stats-arbitrum",
-  80001: "gtrade-stats-mumbai",
+  137: "gtrade-stats-polygon-v2",
+  42161: "gtrade-stats-arbitrum-v2",
+  80001: "gtrade-stats-mumbai-v2",
 };

--- a/packages/graph-client/helpers/rewards.ts
+++ b/packages/graph-client/helpers/rewards.ts
@@ -11,7 +11,7 @@ export const convertPointShareToRewards = (
   points: number,
   totalPoints: number,
   totalReward: number
-) => (points / totalPoints) * totalReward;
+) => (totalPoints === 0 ? 0 : (points / totalPoints) * totalReward);
 
 export const generateId = (
   address: string,

--- a/packages/graph-client/helpers/rewards.ts
+++ b/packages/graph-client/helpers/rewards.ts
@@ -215,6 +215,10 @@ export const WHITELISTED_REFERRAL_ADDRESSES: string[] = [
   "0x6a2664aba79A4F026c2fe34Be983B1Da96795565".toLowerCase(), // hoot
   "0xE7Da4dAAae1BD738A071500dca1d37E9d48b965D".toLowerCase(), // giba
   "0x3161d1f5edb3f9ceebfb3e258681484b82ae3ea4".toLowerCase(), // june
+  "0x38a0FceA985F77e955D7526d569E695536EaA551".toLowerCase(), // talkchain epoch 6
+  "0xdD4D5538F0d7C364272c927d39216A22de0B0482".toLowerCase(), // wang epoch 6
+  "0x3Af0e0Cb6E87D67C2708debb77AE3F8ACD7493b5".toLowerCase(), // sparegas4lambro epoch 6
+  "0x8521058b9a8c48346e02d263884b7E2Bd504deC8".toLowerCase(), // reetika epoch 6
 ];
 export const WHITELISTED_REFEREE_MULTIPLIER = 0.1;
 export const WHITELISTED_REFERRER_MULTIPLIER = 0.15;

--- a/packages/graph-client/helpers/rewards.ts
+++ b/packages/graph-client/helpers/rewards.ts
@@ -249,3 +249,8 @@ export const getLocalEpochNumber = (
 ): number => {
   return epochNumber - rewardConfig.startingEpoch;
 };
+
+export const TOTAL_CLOSED_TRADES_THRESHOLD_ABSOLUTE = 3;
+export const TOTAL_CLOSED_DAYS_THRESHOLD_ABSOLUTE = 2;
+export const TOTAL_CLOSED_TRADES_THRESHOLD_RELATIVE = 5;
+export const TOTAL_CLOSED_DAYS_THRESHOLD_RELATIVE = 2;

--- a/packages/graph-client/helpers/rewards.ts
+++ b/packages/graph-client/helpers/rewards.ts
@@ -11,7 +11,7 @@ export const convertPointShareToRewards = (
   points: number,
   totalPoints: number,
   totalReward: number
-) => (totalPoints === 0 ? 0 : (points / totalPoints) * totalReward);
+) => (+totalPoints === 0 ? 0 : (+points / +totalPoints) * +totalReward);
 
 export const generateId = (
   address: string,

--- a/packages/graph-client/package.json
+++ b/packages/graph-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gainsnetwork/graph-client",
-  "version": "0.0.4-rc3",
+  "version": "0.0.4-rc4",
   "description": "Client library for Gains Network GraphQL API",
   "main": ".graphclient/index.js",
   "types": ".graphclient/index.d.ts",

--- a/packages/graph-client/package.json
+++ b/packages/graph-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gainsnetwork/graph-client",
-  "version": "0.0.3",
+  "version": "0.0.4-rc1",
   "description": "Client library for Gains Network GraphQL API",
   "main": ".graphclient/index.js",
   "types": ".graphclient/index.d.ts",

--- a/packages/graph-client/package.json
+++ b/packages/graph-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gainsnetwork/graph-client",
-  "version": "0.0.4-rc5",
+  "version": "0.0.4-rc6",
   "description": "Client library for Gains Network GraphQL API",
   "main": ".graphclient/index.js",
   "types": ".graphclient/index.d.ts",

--- a/packages/graph-client/package.json
+++ b/packages/graph-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gainsnetwork/graph-client",
-  "version": "0.0.4-rc1",
+  "version": "0.0.4-rc2",
   "description": "Client library for Gains Network GraphQL API",
   "main": ".graphclient/index.js",
   "types": ".graphclient/index.d.ts",

--- a/packages/graph-client/package.json
+++ b/packages/graph-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gainsnetwork/graph-client",
-  "version": "0.0.4-rc2",
+  "version": "0.0.4-rc3",
   "description": "Client library for Gains Network GraphQL API",
   "main": ".graphclient/index.js",
   "types": ".graphclient/index.d.ts",

--- a/packages/graph-client/package.json
+++ b/packages/graph-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gainsnetwork/graph-client",
-  "version": "0.0.4-rc4",
+  "version": "0.0.4-rc5",
   "description": "Client library for Gains Network GraphQL API",
   "main": ".graphclient/index.js",
   "types": ".graphclient/index.d.ts",

--- a/packages/graph-client/queries/gtrade-stats.gql
+++ b/packages/graph-client/queries/gtrade-stats.gql
@@ -9,6 +9,8 @@ fragment BaseEpochTradingPointsRecord on EpochTradingPointsRecord {
   relSkillPoints
   diversityPoints
   totalFeesPaid
+  isAbsSkillEligible
+  isRelSkillEligible
 }
 
 fragment BaseEpochTradingStatsRecord on EpochTradingStatsRecord {

--- a/packages/graph-client/queries/gtrade-stats.gql
+++ b/packages/graph-client/queries/gtrade-stats.gql
@@ -26,6 +26,10 @@ fragment BaseEpochTradingStatsRecord on EpochTradingStatsRecord {
   totalTriggerFees
   totalStakerFees
   totalLpFees
+  totalOpenedTrades
+  totalClosedTrades
+  totalDaysOpenedTrades
+  totalDaysClosedTrades
 }
 
 query GetEpochTradingStatsRecord($id: ID!) {

--- a/packages/stats-subgraph/config/arbitrum.json
+++ b/packages/stats-subgraph/config/arbitrum.json
@@ -2,7 +2,7 @@
   "network": "arbitrum-one",
   "graft": {
     "base": "QmVwR9busBFpKnVc21qXk5d5TJg2c8hs2pnvCKvdkhfzAE",
-    "block": 175926396
+    "block": 178763088
   },
   "DAI": {
     "gnsTradingCallbacksV6_4_1": {

--- a/packages/stats-subgraph/config/arbitrum.json
+++ b/packages/stats-subgraph/config/arbitrum.json
@@ -1,5 +1,9 @@
 {
   "network": "arbitrum-one",
+  "graft": {
+    "base": "QmVwR9busBFpKnVc21qXk5d5TJg2c8hs2pnvCKvdkhfzAE",
+    "block": 175926396
+  },
   "DAI": {
     "gnsTradingCallbacksV6_4_1": {
       "address": "0x298a695906e16aeA0a184A2815A76eAd1a0b7522",

--- a/packages/stats-subgraph/config/mumbai.json
+++ b/packages/stats-subgraph/config/mumbai.json
@@ -1,7 +1,7 @@
 {
   "network": "mumbai",
   "graft": {
-    "base": "QmeSA1KBLp7hvr9DB195ptBReEZPianbcs8dq5Kepj76c2",
+    "base": "QmfBvRkMac88tE5Q153E3o4uHwtdyo3SFtx2XvchYBs2Sh",
     "block": 45370028
   },
   "DAI": {

--- a/packages/stats-subgraph/config/mumbai.json
+++ b/packages/stats-subgraph/config/mumbai.json
@@ -2,7 +2,7 @@
   "network": "mumbai",
   "graft": {
     "base": "QmfBvRkMac88tE5Q153E3o4uHwtdyo3SFtx2XvchYBs2Sh",
-    "block": 45370028
+    "block": 45699852
   },
   "DAI": {
     "gnsTradingCallbacksV6_4_1": {

--- a/packages/stats-subgraph/config/mumbai.json
+++ b/packages/stats-subgraph/config/mumbai.json
@@ -1,5 +1,9 @@
 {
   "network": "mumbai",
+  "graft": {
+    "base": "QmeSA1KBLp7hvr9DB195ptBReEZPianbcs8dq5Kepj76c2",
+    "block": 45370028
+  },
   "DAI": {
     "gnsTradingCallbacksV6_4_1": {
       "address": "0xA7443A20B42f9156F7D9DB01e51523C42CAC8eCE",

--- a/packages/stats-subgraph/config/polygon.json
+++ b/packages/stats-subgraph/config/polygon.json
@@ -1,5 +1,9 @@
 {
   "network": "matic",
+  "graft": {
+    "base": "QmeqJLLuQncHNzmX8ijZ2aqkUnPJ5D1hYEQfpTaHTBz4mr",
+    "block": 52950324
+  },
   "DAI": {
     "gnsTradingCallbacksV6_4_1": {
       "address": "0x82e59334da8C667797009BBe82473B55c7A6b311",

--- a/packages/stats-subgraph/config/polygon.json
+++ b/packages/stats-subgraph/config/polygon.json
@@ -2,7 +2,7 @@
   "network": "matic",
   "graft": {
     "base": "QmVdb67zpqqUT1RkbPch622SM1ofjgxS4ELHkex2AUhour",
-    "block": 52950324
+    "block": 53282482
   },
   "DAI": {
     "gnsTradingCallbacksV6_4_1": {

--- a/packages/stats-subgraph/config/polygon.json
+++ b/packages/stats-subgraph/config/polygon.json
@@ -1,7 +1,7 @@
 {
   "network": "matic",
   "graft": {
-    "base": "QmeqJLLuQncHNzmX8ijZ2aqkUnPJ5D1hYEQfpTaHTBz4mr",
+    "base": "QmVdb67zpqqUT1RkbPch622SM1ofjgxS4ELHkex2AUhour",
     "block": 52950324
   },
   "DAI": {

--- a/packages/stats-subgraph/package.json
+++ b/packages/stats-subgraph/package.json
@@ -20,9 +20,9 @@
     "prepare:arbitrum": "mustache config/arbitrum.json subgraph.yaml.mustache > subgraph.yaml",
     "prepare:polygon": "mustache config/polygon.json subgraph.yaml.mustache > subgraph.yaml",
     "prepare:mumbai": "mustache config/mumbai.json subgraph.yaml.mustache > subgraph.yaml",
-    "deploy:arbitrum": "pnpm clean && pnpm configure:arbitrum && pnpm deploy:hosted gainsnetwork-org/gtrade-stats-arbitrum",
-    "deploy:polygon": "pnpm clean && pnpm configure:polygon && pnpm deploy:hosted gainsnetwork-org/gtrade-stats-polygon",
-    "deploy:mumbai": "pnpm clean && pnpm configure:mumbai && pnpm deploy:hosted gainsnetwork-org/gtrade-stats-mumbai"
+    "deploy:arbitrum": "pnpm clean && pnpm configure:arbitrum && pnpm deploy:hosted gainsnetwork-org/gtrade-stats-arbitrum-v2",
+    "deploy:polygon": "pnpm clean && pnpm configure:polygon && pnpm deploy:hosted gainsnetwork-org/gtrade-stats-polygon-v2",
+    "deploy:mumbai": "pnpm clean && pnpm configure:mumbai && pnpm deploy:hosted gainsnetwork-org/gtrade-stats-mumbai-v2"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "^0.58.0",

--- a/packages/stats-subgraph/schema.gql
+++ b/packages/stats-subgraph/schema.gql
@@ -57,10 +57,10 @@ type EpochTradingStatsRecord @entity {
   totalLpFees: BigDecimal!
 
   "Total opened trades"
-  totalOpenedTrades: Int!
+  totalOpenedTrades: Int
 
   "Total closed trades"
-  totalClosedTrades: Int!
+  totalClosedTrades: Int
 
   "Total days a trade was closed"
   totalDaysClosedTrades: Int

--- a/packages/stats-subgraph/schema.gql
+++ b/packages/stats-subgraph/schema.gql
@@ -85,4 +85,6 @@ type EpochTradingPointsRecord @entity {
   absSkillPoints: BigDecimal!
   relSkillPoints: BigDecimal!
   diversityPoints: BigDecimal!
+  isAbsSkillEligible: Boolean
+  isRelSkillEligible: Boolean
 }

--- a/packages/stats-subgraph/schema.gql
+++ b/packages/stats-subgraph/schema.gql
@@ -55,6 +55,12 @@ type EpochTradingStatsRecord @entity {
 
   "Total lp fees"
   totalLpFees: BigDecimal!
+
+  "Total opened trades"
+  totalOpenedTrades: Int
+
+  "Total closed trades"
+  totalClosedTrades: Int
 }
 
 type EpochTradingPointsRecord @entity {

--- a/packages/stats-subgraph/schema.gql
+++ b/packages/stats-subgraph/schema.gql
@@ -57,10 +57,16 @@ type EpochTradingStatsRecord @entity {
   totalLpFees: BigDecimal!
 
   "Total opened trades"
-  totalOpenedTrades: Int
+  totalOpenedTrades: Int!
 
   "Total closed trades"
-  totalClosedTrades: Int
+  totalClosedTrades: Int!
+
+  "Total days a trade was closed"
+  totalDaysClosedTrades: Int
+
+  "Total days a trade was opened"
+  totalDaysOpenedTrades: Int
 }
 
 type EpochTradingPointsRecord @entity {

--- a/packages/stats-subgraph/src/utils/access/calculatePoints.ts
+++ b/packages/stats-subgraph/src/utils/access/calculatePoints.ts
@@ -1,5 +1,8 @@
 import { Address, BigDecimal, dataSource, log } from "@graphprotocol/graph-ts";
-import { EpochTradingPointsRecord } from "../../types/schema";
+import {
+  EpochTradingPointsRecord,
+  EpochTradingStatsRecord,
+} from "../../types/schema";
 import {
   ZERO_BD,
   EPOCH_TYPE,
@@ -22,7 +25,8 @@ export function updatePointsOnClose(
   pnlPercentage: BigDecimal,
   groupNumber: i32,
   pairNumber: i32,
-  volume: BigDecimal
+  volume: BigDecimal,
+  weeklyStats: EpochTradingStatsRecord
 ): void {
   // load all 4 entries: UserDaily, ProtocolDaily, UserWeekly, ProtocolWeekly
   const userDailyPoints = createOrLoadEpochTradingPointsRecord(
@@ -63,7 +67,7 @@ export function updatePointsOnClose(
   );
 
   // Determine if trader is eligible yet for relative skill points
-  if (isUserEligibleForRelativeSkillPoints(userDailyPoints, userWeeklyPoints)) {
+  if (isTraderEligibleForRelativeSkillPoints(weeklyStats)) {
     updateRelativeSkillPoints(
       userDailyPoints,
       protocolDailyPoints,
@@ -515,8 +519,11 @@ export function createOrLoadEpochTradingPointsRecord(
   return epochTradingPointsRecord as EpochTradingPointsRecord;
 }
 
-function isUserEligibleForRelativeSkillPoints(a, b) {
-  // Determine if trader has opened 5 trades
+function isTraderEligibleForRelativeSkillPoints(
+  weeklyStats: EpochTradingStatsRecord
+) {
+  // Determine if trader has closed 5 trades
+
   // Determine if trader has traded 2 days
-  return true;
+  return weeklyStats.totalClosedTrades > 5 && weeklyStats.totalDaysTraded > 2;
 }

--- a/packages/stats-subgraph/src/utils/access/calculatePoints.ts
+++ b/packages/stats-subgraph/src/utils/access/calculatePoints.ts
@@ -535,7 +535,7 @@ export function createOrLoadEpochTradingPointsRecord(
   return epochTradingPointsRecord as EpochTradingPointsRecord;
 }
 
-const EPOCH_ELIGIBILITY_CHECK_START = 6;
+const EPOCH_ELIGIBILITY_CHECK_START = 7;
 export const TOTAL_CLOSED_TRADES_THRESHOLD_RELATIVE = 5;
 export const TOTAL_CLOSED_DAYS_THRESHOLD_RELATIVE = 2;
 function isTraderEligibleForRelativeSkillPoints(

--- a/packages/stats-subgraph/src/utils/access/calculatePoints.ts
+++ b/packages/stats-subgraph/src/utils/access/calculatePoints.ts
@@ -266,13 +266,24 @@ export function calculateSkillPoints(
     : protocolStat.relSkillPoints;
   let protocolNewPts = ZERO_BD;
 
+  if (absolute && !isTraderEligibleForAbsoluteSkillPoints(weeklyStats)) {
+    return protocolOldPts;
+  }
+
+  if (!absolute && !isTraderEligibleForRelativeSkillPoints(weeklyStats)) {
+    return protocolOldPts;
+  }
+
   if (
     absolute
       ? didTraderJustBecomeEligibleForAbsoluteSkillPoints(weeklyStats)
       : didTraderJustBecomeEligibleForRelativeSkillPoints(weeklyStats)
   ) {
     // Use trader weekly pnl since trader just became eligible
-    if (weeklyStats.totalPnl > ZERO_BD) {
+    if (
+      (absolute && weeklyStats.totalPnl > ZERO_BD) ||
+      (!absolute && weeklyStats.totalPnlPercentage > ZERO_BD)
+    ) {
       protocolNewPts = protocolOldPts.plus(
         absolute ? weeklyStats.totalPnl : weeklyStats.totalPnlPercentage
       );

--- a/packages/stats-subgraph/src/utils/access/calculatePoints.ts
+++ b/packages/stats-subgraph/src/utils/access/calculatePoints.ts
@@ -64,7 +64,10 @@ export function updatePointsOnClose(
       protocolDailyPoints,
       userWeeklyPoints,
       protocolWeeklyPoints,
-      !userWeeklyPoints.isAbsSkillEligible ? weeklyStats.totalPnl : pnl // if trader just became eligible, use totalPnl
+      userWeeklyPoints.epochNumber >= EPOCH_ELIGIBILITY_CHECK_START &&
+        !userWeeklyPoints.isAbsSkillEligible
+        ? weeklyStats.totalPnl
+        : pnl // if trader just became eligible, use totalPnl
     );
   }
   // Determine if trader is eligible yet for relative skill points
@@ -74,7 +77,8 @@ export function updatePointsOnClose(
       protocolDailyPoints,
       userWeeklyPoints,
       protocolWeeklyPoints,
-      !userWeeklyPoints.isRelSkillEligible // if trader just became eligible, use totalPnlPercentage
+      userWeeklyPoints.epochNumber >= EPOCH_ELIGIBILITY_CHECK_START &&
+        !userWeeklyPoints.isRelSkillEligible // if trader just became eligible, use totalPnlPercentage
         ? weeklyStats.totalPnlPercentage
         : pnlPercentage
     );

--- a/packages/stats-subgraph/src/utils/access/calculatePoints.ts
+++ b/packages/stats-subgraph/src/utils/access/calculatePoints.ts
@@ -522,8 +522,7 @@ export function createOrLoadEpochTradingPointsRecord(
 function isTraderEligibleForRelativeSkillPoints(
   weeklyStats: EpochTradingStatsRecord
 ) {
-  // Determine if trader has closed 5 trades
-
-  // Determine if trader has traded 2 days
-  return weeklyStats.totalClosedTrades > 5 && weeklyStats.totalDaysTraded > 2;
+  return (
+    weeklyStats.totalClosedTrades >= 5 && weeklyStats.totalDaysClosedTrades >= 2
+  );
 }

--- a/packages/stats-subgraph/src/utils/access/calculatePoints.ts
+++ b/packages/stats-subgraph/src/utils/access/calculatePoints.ts
@@ -547,6 +547,8 @@ export function createOrLoadEpochTradingPointsRecord(
 }
 
 const EPOCH_ELIGIBILITY_CHECK_START = 6;
+export const TOTAL_CLOSED_TRADES_THRESHOLD_RELATIVE = 5;
+export const TOTAL_CLOSED_DAYS_THRESHOLD_RELATIVE = 2;
 function isTraderEligibleForRelativeSkillPoints(
   weeklyStats: EpochTradingStatsRecord
 ): boolean {
@@ -555,7 +557,8 @@ function isTraderEligibleForRelativeSkillPoints(
   }
 
   return (
-    weeklyStats.totalClosedTrades >= 5 && weeklyStats.totalDaysClosedTrades >= 1
+    weeklyStats.totalClosedTrades >= TOTAL_CLOSED_TRADES_THRESHOLD_RELATIVE &&
+    weeklyStats.totalDaysClosedTrades >= TOTAL_CLOSED_DAYS_THRESHOLD_RELATIVE
   );
 }
 
@@ -563,10 +566,13 @@ function didTraderJustBecomeEligibleForRelativeSkillPoints(
   weeklyStats: EpochTradingStatsRecord
 ): boolean {
   return (
-    weeklyStats.totalClosedTrades == 5 && weeklyStats.totalDaysClosedTrades == 1
+    weeklyStats.totalClosedTrades == TOTAL_CLOSED_TRADES_THRESHOLD_RELATIVE &&
+    weeklyStats.totalDaysClosedTrades == TOTAL_CLOSED_DAYS_THRESHOLD_RELATIVE
   );
 }
 
+export const TOTAL_CLOSED_TRADES_THRESHOLD_ABSOLUTE = 3;
+export const TOTAL_CLOSED_DAYS_THRESHOLD_ABSOLUTE = 2;
 function isTraderEligibleForAbsoluteSkillPoints(
   weeklyStats: EpochTradingStatsRecord
 ): boolean {
@@ -575,7 +581,8 @@ function isTraderEligibleForAbsoluteSkillPoints(
   }
 
   return (
-    weeklyStats.totalClosedTrades >= 3 && weeklyStats.totalDaysClosedTrades >= 1
+    weeklyStats.totalClosedTrades >= TOTAL_CLOSED_TRADES_THRESHOLD_ABSOLUTE &&
+    weeklyStats.totalDaysClosedTrades >= TOTAL_CLOSED_DAYS_THRESHOLD_ABSOLUTE
   );
 }
 
@@ -583,6 +590,7 @@ function didTraderJustBecomeEligibleForAbsoluteSkillPoints(
   weeklyStats: EpochTradingStatsRecord
 ): boolean {
   return (
-    weeklyStats.totalClosedTrades == 3 && weeklyStats.totalDaysClosedTrades == 1
+    weeklyStats.totalClosedTrades == TOTAL_CLOSED_TRADES_THRESHOLD_ABSOLUTE &&
+    weeklyStats.totalDaysClosedTrades == TOTAL_CLOSED_DAYS_THRESHOLD_ABSOLUTE
   );
 }

--- a/packages/stats-subgraph/src/utils/access/calculatePoints.ts
+++ b/packages/stats-subgraph/src/utils/access/calculatePoints.ts
@@ -339,7 +339,8 @@ export function updateFeePoints(
   const referrerDetails = isTraderReferredByWhitelistedReferral(
     dataSource.network(),
     Address.fromString(userDailyStats.address),
-    blockNumber
+    blockNumber,
+    protocolWeeklyStats.epochNumber
   );
   let referrerPointBoost = ZERO_BD;
   let refereePointBoost = ZERO_BD;

--- a/packages/stats-subgraph/src/utils/access/calculatePoints.ts
+++ b/packages/stats-subgraph/src/utils/access/calculatePoints.ts
@@ -519,9 +519,14 @@ export function createOrLoadEpochTradingPointsRecord(
   return epochTradingPointsRecord as EpochTradingPointsRecord;
 }
 
+const EPOCH_ELIGIBILITY_CHECK_START = 6;
 function isTraderEligibleForRelativeSkillPoints(
   weeklyStats: EpochTradingStatsRecord
 ) {
+  if (weeklyStats.epochNumber < EPOCH_ELIGIBILITY_CHECK_START) {
+    return true;
+  }
+
   return (
     weeklyStats.totalClosedTrades >= 5 && weeklyStats.totalDaysClosedTrades >= 2
   );

--- a/packages/stats-subgraph/src/utils/access/calculatePoints.ts
+++ b/packages/stats-subgraph/src/utils/access/calculatePoints.ts
@@ -64,9 +64,7 @@ export function updatePointsOnClose(
       protocolDailyPoints,
       userWeeklyPoints,
       protocolWeeklyPoints,
-      didTraderJustBecomeEligibleForAbsoluteSkillPoints(weeklyStats)
-        ? weeklyStats.totalPnl
-        : pnl
+      !userWeeklyPoints.isAbsSkillEligible ? weeklyStats.totalPnl : pnl // if trader just became eligible, use totalPnl
     );
   }
   // Determine if trader is eligible yet for relative skill points
@@ -76,7 +74,7 @@ export function updatePointsOnClose(
       protocolDailyPoints,
       userWeeklyPoints,
       protocolWeeklyPoints,
-      didTraderJustBecomeEligibleForRelativeSkillPoints(weeklyStats)
+      !userWeeklyPoints.isRelSkillEligible // if trader just became eligible, use totalPnlPercentage
         ? weeklyStats.totalPnlPercentage
         : pnlPercentage
     );
@@ -133,6 +131,9 @@ export function updateAbsoluteSkillPoints(
   userWeeklyPoints.absSkillPoints = userWeeklySkillPoints;
   protocolWeeklyPoints.absSkillPoints = protocolWeeklySkillPoints;
 
+  userWeeklyPoints.isAbsSkillEligible = true;
+  userDailyPoints.isAbsSkillEligible = true;
+
   // Saving all the entities
   userDailyPoints.save();
   protocolDailyPoints.save();
@@ -183,6 +184,9 @@ export function updateRelativeSkillPoints(
   protocolDailyPoints.relSkillPoints = protocolDailySkillPoints;
   userWeeklyPoints.relSkillPoints = userWeeklySkillPoints;
   protocolWeeklyPoints.relSkillPoints = protocolWeeklySkillPoints;
+
+  userWeeklyPoints.isRelSkillEligible = true;
+  userDailyPoints.isRelSkillEligible = true;
 
   // Saving all the entities
   userDailyPoints.save();
@@ -518,6 +522,8 @@ export function createOrLoadEpochTradingPointsRecord(
     epochTradingPointsRecord.absSkillPoints = BigDecimal.fromString("0");
     epochTradingPointsRecord.relSkillPoints = BigDecimal.fromString("0");
     epochTradingPointsRecord.feePoints = BigDecimal.fromString("0");
+    epochTradingPointsRecord.isAbsSkillEligible = false;
+    epochTradingPointsRecord.isRelSkillEligible = false;
     if (save) {
       epochTradingPointsRecord.save();
     }
@@ -541,15 +547,6 @@ function isTraderEligibleForRelativeSkillPoints(
   );
 }
 
-function didTraderJustBecomeEligibleForRelativeSkillPoints(
-  weeklyStats: EpochTradingStatsRecord
-): boolean {
-  return (
-    weeklyStats.totalClosedTrades == TOTAL_CLOSED_TRADES_THRESHOLD_RELATIVE &&
-    weeklyStats.totalDaysClosedTrades == TOTAL_CLOSED_DAYS_THRESHOLD_RELATIVE
-  );
-}
-
 export const TOTAL_CLOSED_TRADES_THRESHOLD_ABSOLUTE = 3;
 export const TOTAL_CLOSED_DAYS_THRESHOLD_ABSOLUTE = 2;
 function isTraderEligibleForAbsoluteSkillPoints(
@@ -562,14 +559,5 @@ function isTraderEligibleForAbsoluteSkillPoints(
   return (
     weeklyStats.totalClosedTrades >= TOTAL_CLOSED_TRADES_THRESHOLD_ABSOLUTE &&
     weeklyStats.totalDaysClosedTrades >= TOTAL_CLOSED_DAYS_THRESHOLD_ABSOLUTE
-  );
-}
-
-function didTraderJustBecomeEligibleForAbsoluteSkillPoints(
-  weeklyStats: EpochTradingStatsRecord
-): boolean {
-  return (
-    weeklyStats.totalClosedTrades == TOTAL_CLOSED_TRADES_THRESHOLD_ABSOLUTE &&
-    weeklyStats.totalDaysClosedTrades == TOTAL_CLOSED_DAYS_THRESHOLD_ABSOLUTE
   );
 }

--- a/packages/stats-subgraph/src/utils/access/calculatePoints.ts
+++ b/packages/stats-subgraph/src/utils/access/calculatePoints.ts
@@ -58,13 +58,15 @@ export function updatePointsOnClose(
     false
   );
 
-  updateAbsoluteSkillPoints(
-    userDailyPoints,
-    protocolDailyPoints,
-    userWeeklyPoints,
-    protocolWeeklyPoints,
-    pnl
-  );
+  if (isTraderEligibleForAbsoluteSkillPoints(weeklyStats)) {
+    updateAbsoluteSkillPoints(
+      userDailyPoints,
+      protocolDailyPoints,
+      userWeeklyPoints,
+      protocolWeeklyPoints,
+      pnl
+    );
+  }
 
   // Determine if trader is eligible yet for relative skill points
   if (isTraderEligibleForRelativeSkillPoints(weeklyStats)) {
@@ -530,5 +532,17 @@ function isTraderEligibleForRelativeSkillPoints(
 
   return (
     weeklyStats.totalClosedTrades >= 5 && weeklyStats.totalDaysClosedTrades >= 2
+  );
+}
+
+function isTraderEligibleForAbsoluteSkillPoints(
+  weeklyStats: EpochTradingStatsRecord
+) {
+  if (weeklyStats.epochNumber < EPOCH_ELIGIBILITY_CHECK_START) {
+    return true;
+  }
+
+  return (
+    weeklyStats.totalClosedTrades >= 3 && weeklyStats.totalDaysClosedTrades >= 2
   );
 }

--- a/packages/stats-subgraph/src/utils/access/calculatePoints.ts
+++ b/packages/stats-subgraph/src/utils/access/calculatePoints.ts
@@ -64,10 +64,11 @@ export function updatePointsOnClose(
       protocolDailyPoints,
       userWeeklyPoints,
       protocolWeeklyPoints,
-      pnl
+      didTraderJustBecomeEligibleForAbsoluteSkillPoints(weeklyStats)
+        ? weeklyStats.totalPnl
+        : pnl
     );
   }
-
   // Determine if trader is eligible yet for relative skill points
   if (isTraderEligibleForRelativeSkillPoints(weeklyStats)) {
     updateRelativeSkillPoints(
@@ -75,7 +76,9 @@ export function updatePointsOnClose(
       protocolDailyPoints,
       userWeeklyPoints,
       protocolWeeklyPoints,
-      pnlPercentage
+      didTraderJustBecomeEligibleForRelativeSkillPoints(weeklyStats)
+        ? weeklyStats.totalPnlPercentage
+        : pnlPercentage
     );
   }
 
@@ -535,6 +538,14 @@ function isTraderEligibleForRelativeSkillPoints(
   );
 }
 
+function didTraderJustBecomeEligibleForRelativeSkillPoints(
+  weeklyStats: EpochTradingStatsRecord
+): boolean {
+  return (
+    weeklyStats.totalClosedTrades == 5 && weeklyStats.totalDaysClosedTrades == 2
+  );
+}
+
 function isTraderEligibleForAbsoluteSkillPoints(
   weeklyStats: EpochTradingStatsRecord
 ): boolean {
@@ -544,5 +555,13 @@ function isTraderEligibleForAbsoluteSkillPoints(
 
   return (
     weeklyStats.totalClosedTrades >= 3 && weeklyStats.totalDaysClosedTrades >= 2
+  );
+}
+
+function didTraderJustBecomeEligibleForAbsoluteSkillPoints(
+  weeklyStats: EpochTradingStatsRecord
+): boolean {
+  return (
+    weeklyStats.totalClosedTrades == 3 && weeklyStats.totalDaysClosedTrades == 2
   );
 }

--- a/packages/stats-subgraph/src/utils/access/calculatePoints.ts
+++ b/packages/stats-subgraph/src/utils/access/calculatePoints.ts
@@ -525,7 +525,7 @@ export function createOrLoadEpochTradingPointsRecord(
 const EPOCH_ELIGIBILITY_CHECK_START = 6;
 function isTraderEligibleForRelativeSkillPoints(
   weeklyStats: EpochTradingStatsRecord
-) {
+): boolean {
   if (weeklyStats.epochNumber < EPOCH_ELIGIBILITY_CHECK_START) {
     return true;
   }
@@ -537,7 +537,7 @@ function isTraderEligibleForRelativeSkillPoints(
 
 function isTraderEligibleForAbsoluteSkillPoints(
   weeklyStats: EpochTradingStatsRecord
-) {
+): boolean {
   if (weeklyStats.epochNumber < EPOCH_ELIGIBILITY_CHECK_START) {
     return true;
   }

--- a/packages/stats-subgraph/src/utils/access/calculatePoints.ts
+++ b/packages/stats-subgraph/src/utils/access/calculatePoints.ts
@@ -61,13 +61,18 @@ export function updatePointsOnClose(
     protocolWeeklyPoints,
     pnl
   );
-  updateRelativeSkillPoints(
-    userDailyPoints,
-    protocolDailyPoints,
-    userWeeklyPoints,
-    protocolWeeklyPoints,
-    pnlPercentage
-  );
+
+  // Determine if trader is eligible yet for relative skill points
+  if (isUserEligibleForRelativeSkillPoints(userDailyPoints, userWeeklyPoints)) {
+    updateRelativeSkillPoints(
+      userDailyPoints,
+      protocolDailyPoints,
+      userWeeklyPoints,
+      protocolWeeklyPoints,
+      pnlPercentage
+    );
+  }
+
   updateDiversityPoints(
     userDailyPoints,
     protocolDailyPoints,
@@ -508,4 +513,10 @@ export function createOrLoadEpochTradingPointsRecord(
     }
   }
   return epochTradingPointsRecord as EpochTradingPointsRecord;
+}
+
+function isUserEligibleForRelativeSkillPoints(a, b) {
+  // Determine if trader has opened 5 trades
+  // Determine if trader has traded 2 days
+  return true;
 }

--- a/packages/stats-subgraph/src/utils/access/epochTradingStatsRecord.ts
+++ b/packages/stats-subgraph/src/utils/access/epochTradingStatsRecord.ts
@@ -261,6 +261,8 @@ function _addOpenTradeStats(
     currentStats.pairsTraded = pairsTradedArray;
   }
 
+  currentStats.totalOpenedTrades = currentStats.totalOpenedTrades + 1;
+
   currentStats.save();
   return currentStats;
 }
@@ -305,6 +307,8 @@ function _addCloseTradeStats(
     pairsTradedArray.push(pairIndex);
     currentStats.pairsTraded = pairsTradedArray;
   }
+
+  currentStats.totalClosedTrades = currentStats.totalClosedTrades + 1;
 
   currentStats.save();
   return currentStats;

--- a/packages/stats-subgraph/src/utils/access/epochTradingStatsRecord.ts
+++ b/packages/stats-subgraph/src/utils/access/epochTradingStatsRecord.ts
@@ -67,6 +67,10 @@ export function createOrLoadEpochTradingStatsRecord(
     epochTradingStatsRecord.totalTriggerFees = ZERO_BD;
     epochTradingStatsRecord.totalLpFees = ZERO_BD;
     epochTradingStatsRecord.totalStakerFees = ZERO_BD;
+    epochTradingStatsRecord.totalOpenedTrades = 0;
+    epochTradingStatsRecord.totalClosedTrades = 0;
+    epochTradingStatsRecord.totalDaysOpenedTrades = 0;
+    epochTradingStatsRecord.totalDaysClosedTrades = 0;
 
     if (save) {
       epochTradingStatsRecord.save();
@@ -119,7 +123,7 @@ export function addOpenTradeStats(data: addOpenTradeStatsInput): void {
     collateral,
     false
   );
-  _addOpenTradeStats(data, weeklyStats);
+  _addOpenTradeStats(data, weeklyStats, dailyStats.totalOpenedTrades == 1);
 
   // Daily protocol stats
   const dailyProtocolStats = createOrLoadEpochTradingStatsRecord(
@@ -139,7 +143,11 @@ export function addOpenTradeStats(data: addOpenTradeStatsInput): void {
     collateral,
     false
   );
-  _addOpenTradeStats(data, weeklyProtocolStats);
+  _addOpenTradeStats(
+    data,
+    weeklyProtocolStats,
+    dailyProtocolStats.totalOpenedTrades == 1
+  );
 }
 
 export class addCloseTradeStatsInput {
@@ -195,7 +203,7 @@ export function addCloseTradeStats(data: addCloseTradeStatsInput): void {
     collateral,
     false
   );
-  _addCloseTradeStats(data, weeklyStats);
+  _addCloseTradeStats(data, weeklyStats, dailyStats.totalClosedTrades == 1);
 
   // Daily protocol stats
   const dailyProtocolStats = createOrLoadEpochTradingStatsRecord(
@@ -215,7 +223,11 @@ export function addCloseTradeStats(data: addCloseTradeStatsInput): void {
     collateral,
     false
   );
-  _addCloseTradeStats(data, weeklyProtocolStats);
+  _addCloseTradeStats(
+    data,
+    weeklyProtocolStats,
+    dailyProtocolStats.totalClosedTrades == 1
+  );
 
   updatePointsOnClose(
     address,
@@ -226,7 +238,8 @@ export function addCloseTradeStats(data: addCloseTradeStatsInput): void {
     data.pnlPercentage,
     data.groupIndex,
     data.pairIndex,
-    data.positionSize
+    data.positionSize,
+    weeklyStats
   );
 }
 
@@ -235,7 +248,8 @@ export function addCloseTradeStats(data: addCloseTradeStatsInput): void {
  */
 function _addOpenTradeStats(
   data: addOpenTradeStatsInput,
-  currentStats: EpochTradingStatsRecord
+  currentStats: EpochTradingStatsRecord,
+  firstOpenedTrade: boolean = false
 ): EpochTradingStatsRecord {
   const pairIndex = data.pairIndex;
   const groupIndex = data.groupIndex;
@@ -263,6 +277,10 @@ function _addOpenTradeStats(
 
   currentStats.totalOpenedTrades = currentStats.totalOpenedTrades + 1;
 
+  if (firstOpenedTrade) {
+    currentStats.totalDaysOpenedTrades = currentStats.totalDaysOpenedTrades + 1;
+  }
+
   currentStats.save();
   return currentStats;
 }
@@ -272,7 +290,8 @@ function _addOpenTradeStats(
  */
 function _addCloseTradeStats(
   data: addCloseTradeStatsInput,
-  currentStats: EpochTradingStatsRecord
+  currentStats: EpochTradingStatsRecord,
+  firstClosedTrade: boolean = false
 ): EpochTradingStatsRecord {
   const pairIndex = data.pairIndex;
   const groupIndex = data.groupIndex;
@@ -309,6 +328,10 @@ function _addCloseTradeStats(
   }
 
   currentStats.totalClosedTrades = currentStats.totalClosedTrades + 1;
+
+  if (firstClosedTrade) {
+    currentStats.totalDaysClosedTrades = currentStats.totalDaysClosedTrades + 1;
+  }
 
   currentStats.save();
   return currentStats;

--- a/packages/stats-subgraph/src/utils/constants.ts
+++ b/packages/stats-subgraph/src/utils/constants.ts
@@ -316,9 +316,29 @@ export const WHITELISTED_REFERRAL_ADDRESSES: string[] = [
   "0x6a2664aba79A4F026c2fe34Be983B1Da96795565".toLowerCase(), // hoot
   "0xE7Da4dAAae1BD738A071500dca1d37E9d48b965D".toLowerCase(), // giba
   "0x3161d1f5edb3f9ceebfb3e258681484b82ae3ea4".toLowerCase(), // june
+];
+
+// this is so the subgraph is backwards compatible
+// we don't want these addrsesses whitelisted before epoch 6
+export const EPOCH_6_WHITELISTED_REFERRAL_ADDRESSES: string[] = [
   "0x38a0FceA985F77e955D7526d569E695536EaA551".toLowerCase(), // talkchain 01-31-24
   "0xdD4D5538F0d7C364272c927d39216A22de0B0482".toLowerCase(), // wang 01-31-24
   "0x3Af0e0Cb6E87D67C2708debb77AE3F8ACD7493b5".toLowerCase(), // sparegas4lambro 01-31-24
 ];
+
+export function isWhitelistedReferralByEpoch(
+  referral: string,
+  epoch: i32
+): boolean {
+  if (epoch < 6) {
+    return WHITELISTED_REFERRAL_ADDRESSES.includes(referral);
+  } else {
+    return (
+      WHITELISTED_REFERRAL_ADDRESSES.includes(referral) ||
+      EPOCH_6_WHITELISTED_REFERRAL_ADDRESSES.includes(referral)
+    );
+  }
+}
+
 export const WHITELISTED_REFEREE_MULTIPLIER = BigDecimal.fromString("0.10");
 export const WHITELISTED_REFERRER_MULTIPLIER = BigDecimal.fromString("0.15");

--- a/packages/stats-subgraph/src/utils/constants.ts
+++ b/packages/stats-subgraph/src/utils/constants.ts
@@ -316,6 +316,9 @@ export const WHITELISTED_REFERRAL_ADDRESSES: string[] = [
   "0x6a2664aba79A4F026c2fe34Be983B1Da96795565".toLowerCase(), // hoot
   "0xE7Da4dAAae1BD738A071500dca1d37E9d48b965D".toLowerCase(), // giba
   "0x3161d1f5edb3f9ceebfb3e258681484b82ae3ea4".toLowerCase(), // june
+  "0x38a0FceA985F77e955D7526d569E695536EaA551".toLowerCase(), // talkchain 01-31-24
+  "0xdD4D5538F0d7C364272c927d39216A22de0B0482".toLowerCase(), // wang 01-31-24
+  "0x3Af0e0Cb6E87D67C2708debb77AE3F8ACD7493b5".toLowerCase(), // sparegas4lambro 01-31-24
 ];
 export const WHITELISTED_REFEREE_MULTIPLIER = BigDecimal.fromString("0.10");
 export const WHITELISTED_REFERRER_MULTIPLIER = BigDecimal.fromString("0.15");

--- a/packages/stats-subgraph/src/utils/constants.ts
+++ b/packages/stats-subgraph/src/utils/constants.ts
@@ -324,6 +324,7 @@ export const EPOCH_6_WHITELISTED_REFERRAL_ADDRESSES: string[] = [
   "0x38a0FceA985F77e955D7526d569E695536EaA551".toLowerCase(), // talkchain 01-31-24
   "0xdD4D5538F0d7C364272c927d39216A22de0B0482".toLowerCase(), // wang 01-31-24
   "0x3Af0e0Cb6E87D67C2708debb77AE3F8ACD7493b5".toLowerCase(), // sparegas4lambro 01-31-24
+  "0x8521058b9a8c48346e02d263884b7E2Bd504deC8".toLowerCase(), // reetika 01-31-24
 ];
 
 export function isWhitelistedReferralByEpoch(

--- a/packages/stats-subgraph/src/utils/constants.ts
+++ b/packages/stats-subgraph/src/utils/constants.ts
@@ -320,7 +320,7 @@ export const WHITELISTED_REFERRAL_ADDRESSES: string[] = [
 
 // this is so the subgraph is backwards compatible
 // we don't want these addrsesses whitelisted before epoch 6
-export const EPOCH_6_WHITELISTED_REFERRAL_ADDRESSES: string[] = [
+export const EPOCH_7_WHITELISTED_REFERRAL_ADDRESSES: string[] = [
   "0x38a0FceA985F77e955D7526d569E695536EaA551".toLowerCase(), // talkchain 01-31-24
   "0xdD4D5538F0d7C364272c927d39216A22de0B0482".toLowerCase(), // wang 01-31-24
   "0x3Af0e0Cb6E87D67C2708debb77AE3F8ACD7493b5".toLowerCase(), // sparegas4lambro 01-31-24
@@ -331,12 +331,12 @@ export function isWhitelistedReferralByEpoch(
   referral: string,
   epoch: i32
 ): boolean {
-  if (epoch < 6) {
+  if (epoch < 7) {
     return WHITELISTED_REFERRAL_ADDRESSES.includes(referral);
   } else {
     return (
       WHITELISTED_REFERRAL_ADDRESSES.includes(referral) ||
-      EPOCH_6_WHITELISTED_REFERRAL_ADDRESSES.includes(referral)
+      EPOCH_7_WHITELISTED_REFERRAL_ADDRESSES.includes(referral)
     );
   }
 }

--- a/packages/stats-subgraph/src/utils/contract/GNSReferrals/index.ts
+++ b/packages/stats-subgraph/src/utils/contract/GNSReferrals/index.ts
@@ -6,7 +6,8 @@ import {
   WHITELISTED_REFERRAL_ADDRESSES,
   ZERO_ADDRESS,
   getNetworkAddresses,
-  getMultiCollatBlock
+  getMultiCollatBlock,
+  isWhitelistedReferralByEpoch,
 } from "../../constants";
 
 export function getReferralsContract(network: string): GNSReferrals {
@@ -44,7 +45,7 @@ export function isTraderReferredByAggregator(
   trader: Address,
   blockNumber: i32
 ): boolean {
-  const multiCollatBlock = getMultiCollatBlock(network)
+  const multiCollatBlock = getMultiCollatBlock(network);
   if (blockNumber > multiCollatBlock) {
     const diamond = getMultiCollatDiamondContract(network);
     const referrer = diamond.try_getTraderReferrer(trader);
@@ -75,9 +76,10 @@ export class WhitelisedReferralResponse {
 export function isTraderReferredByWhitelistedReferral(
   network: string,
   trader: Address,
-  blockNumber: i32
+  blockNumber: i32,
+  epochNumber: i32
 ): WhitelisedReferralResponse {
-  const multiCollatBlock = getMultiCollatBlock(network)
+  const multiCollatBlock = getMultiCollatBlock(network);
   if (blockNumber > multiCollatBlock) {
     const diamond = getMultiCollatDiamondContract(network);
     const referrer = diamond.try_getTraderReferrer(trader);
@@ -86,7 +88,7 @@ export function isTraderReferredByWhitelistedReferral(
     }
     const referrerString = referrer.value.toHexString().toLowerCase();
     return {
-      whitelisted: WHITELISTED_REFERRAL_ADDRESSES.includes(referrerString),
+      whitelisted: isWhitelistedReferralByEpoch(referrerString, epochNumber),
       referrer: referrerString,
     };
   } else {
@@ -98,7 +100,7 @@ export function isTraderReferredByWhitelistedReferral(
 
     const referrerString = referrer.value.toHexString().toLowerCase();
     return {
-      whitelisted: WHITELISTED_REFERRAL_ADDRESSES.includes(referrerString),
+      whitelisted: isWhitelistedReferralByEpoch(referrerString, epochNumber),
       referrer: referrerString,
     };
   }

--- a/packages/stats-subgraph/subgraph.yaml.mustache
+++ b/packages/stats-subgraph/subgraph.yaml.mustache
@@ -172,9 +172,3 @@ dataSources:
         - event: DaiVaultFeeCharged(indexed address,uint256)
           handler: handleLpFeeCharged
       file: ./src/handlers/GNSTradingCallbacks/index.ts      
-
-features:
-  - grafting
-graft:
-  base: {{graft.baseSubgraph}}
-  block: {{graft.block}}

--- a/packages/stats-subgraph/subgraph.yaml.mustache
+++ b/packages/stats-subgraph/subgraph.yaml.mustache
@@ -172,3 +172,9 @@ dataSources:
         - event: DaiVaultFeeCharged(indexed address,uint256)
           handler: handleLpFeeCharged
       file: ./src/handlers/GNSTradingCallbacks/index.ts      
+
+features:
+  - grafting
+graft:
+  base: {{graft.baseSubgraph}}
+  block: {{graft.block}}

--- a/packages/stats-subgraph/subgraph.yaml.mustache
+++ b/packages/stats-subgraph/subgraph.yaml.mustache
@@ -3,7 +3,11 @@ description: >-
   gTrade point data
 schema:
   file: ./schema.gql
-
+features:
+  - grafting
+graft:
+  base: {{graft.base}}
+  block: {{graft.block}}
 dataSources:
   - kind: ethereum
     name: GNSTradingCallbacksV6_4_1


### PR DESCRIPTION
**PnL % Eligibility**

* \>=5 trades closed
* \>= 2 days traded

**PnL Eligibility**

* \>=3 trades closed
* \>= 2 days traded

**Schema changes**

To support above eligibility, added four new schema values:
* totalOpenedTrades
* totalClosedTrades
* totalDaysOpenedTrades
* totalDaysClosedTrades

**Referrals**

Added additional referrals. To not break data backwards, I've added them as a second wave starting at epoch 6. So before epoch 6, only the original addresses are checked. 

